### PR TITLE
Update AboutMutability.js

### DIFF
--- a/koans/AboutMutability.js
+++ b/koans/AboutMutability.js
@@ -19,7 +19,7 @@ describe("About Mutability", function() {
     expect(aPerson.firstname).toBe(FILL_ME_IN);
   });
 
-  it("should expect prototype properties to be public and mutable", function () {
+  it("should expect prototype properties to be public and maskable", function () {
     function Person(firstname, lastname)
     {
       this.firstname = firstname;


### PR DESCRIPTION
In this particular test case, the function on Person.prototype is not mutated. Rather, it is because the object `aPerson` itself has the method with the same name `getFullName`, it doesn't need to go to its prototype to find the method anymore.

In summary, both aPerson.getFullName and aPerson.prototype.getFullName exist. The getFullName on the prototype is masked, not mutated.
