### PR TITLE
add two extra test that explain array slicing

### DIFF
--- a/koans/AboutArrays.js
+++ b/koans/AboutArrays.js
@@ -53,6 +53,8 @@ describe("About Arrays", function() {
     expect(array.slice(3, 0)).toEqual(FILL_ME_IN);
     expect(array.slice(3, 100)).toEqual(FILL_ME_IN);
     expect(array.slice(5, 1)).toEqual(FILL_ME_IN);
+    expect(array.slice()).toEqual(FILL_ME_IN);
+    expect(array.slice()).not.toBe(array);
   });
 
   it("should know array references", function () {


### PR DESCRIPTION
The first example shows that slicing an array with no parameters returns a copy of the original array that has the same values. The second test shows that even though both arrays have the same values, its actually a COPY not a reference to the same object.
