### PR TITLE
Replaced Jasmine expect with unexpected

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_size = 2
+indent_style = space

--- a/KoansRunner.html
+++ b/KoansRunner.html
@@ -7,6 +7,8 @@
   <script type="text/javascript" src="lib/jasmine/jasmine.js"></script>
   <script type="text/javascript" src="lib/jasmine/jasmine-html.js"></script>
   <script type="text/javascript" src="lib/jasmine/jskoans-jasmine-html.js"></script>
+  <script type="text/javascript" src="lib/jasmineHtmlMessages.js"></script>
+  <script type="text/javascript" src="lib/unexpected.js"></script>
   
   <script type="text/javascript" src="lib/underscore-min.js"></script>
 
@@ -25,6 +27,7 @@
 <body>
 
 <script type="text/javascript">
+  var expect = weknowhow.expect;
   jasmine.getEnv().addReporter(new JsKoansReporter());
   jasmine.getEnv().execute();
 </script>

--- a/koans/AboutApplyingWhatWeHaveLearnt.js
+++ b/koans/AboutApplyingWhatWeHaveLearnt.js
@@ -32,7 +32,7 @@ describe("About Applying What We Have Learnt", function() {
         }
     }
 
-    expect(productsICanEat.length).toBe(FILL_ME_IN);
+    expect(productsICanEat.length, 'to be', FILL_ME_IN);
   });
 
   it("given I'm allergic to nuts and hate mushrooms, it should find a pizza I can eat (functional)", function () {
@@ -41,7 +41,7 @@ describe("About Applying What We Have Learnt", function() {
 
       /* solve using filter() & all() / any() */
 
-      expect(productsICanEat.length).toBe(FILL_ME_IN);
+      expect(productsICanEat.length, 'to be', FILL_ME_IN);
   });
 
   /*********************************************************************************/
@@ -55,14 +55,14 @@ describe("About Applying What We Have Learnt", function() {
       }
     }
 
-    expect(sum).toBe(FILL_ME_IN);
+    expect(sum, 'to be', FILL_ME_IN);
   });
 
   it("should add all the natural numbers below 1000 that are multiples of 3 or 5 (functional)", function () {
 
     var sum = FILL_ME_IN;    /* try chaining range() and reduce() */
 
-    expect(233168).toBe(FILL_ME_IN);
+    expect(233168, 'to be', FILL_ME_IN);
   });
 
   /*********************************************************************************/
@@ -75,7 +75,7 @@ describe("About Applying What We Have Learnt", function() {
         }
     }
 
-    expect(ingredientCount['mushrooms']).toBe(FILL_ME_IN);
+    expect(ingredientCount['mushrooms'], 'to be', FILL_ME_IN);
   });
 
   it("should count the ingredient occurrence (functional)", function () {
@@ -83,7 +83,8 @@ describe("About Applying What We Have Learnt", function() {
 
     /* chain() together map(), flatten() and reduce() */
 
-    expect(ingredientCount['mushrooms']).toBe(FILL_ME_IN);
+
+    expect(ingredientCount['mushrooms'], 'to be', FILL_ME_IN);
   });
 
   /*********************************************************************************/

--- a/koans/AboutArrays.js
+++ b/koans/AboutArrays.js
@@ -3,56 +3,56 @@ describe("About Arrays", function() {
   //We shall contemplate truth by testing reality, via spec expectations.
   it("should create arrays", function() {
     var emptyArray = [];
-    expect(typeof(emptyArray)).toBe(FILL_ME_IN); //A mistake? - http://javascript.crockford.com/remedial.html
-    expect(emptyArray.length).toBe(FILL_ME_IN);
+    expect(typeof(emptyArray), 'to be', FILL_ME_IN); //A mistake? - http://javascript.crockford.com/remedial.html
+    expect(emptyArray.length, 'to be', FILL_ME_IN);
 
     var multiTypeArray = [0, 1, "two", function () { return 3; }, {value1: 4, value2: 5}, [6, 7]];
-    expect(multiTypeArray[0]).toBe(FILL_ME_IN);
-    expect(multiTypeArray[2]).toBe(FILL_ME_IN);
-    expect(multiTypeArray[3]()).toBe(FILL_ME_IN);
-    expect(multiTypeArray[4].value1).toBe(FILL_ME_IN);
-    expect(multiTypeArray[4]["value2"]).toBe(FILL_ME_IN);
-    expect(multiTypeArray[5][0]).toBe(FILL_ME_IN);
+    expect(multiTypeArray[0], 'to be', FILL_ME_IN);
+    expect(multiTypeArray[2], 'to be', FILL_ME_IN);
+    expect(multiTypeArray[3](), 'to be', FILL_ME_IN);
+    expect(multiTypeArray[4].value1, 'to be', FILL_ME_IN);
+    expect(multiTypeArray[4]["value2"], 'to be', FILL_ME_IN);
+    expect(multiTypeArray[5][0], 'to be', FILL_ME_IN);
   });
 
   it("should understand array literals", function () {
     var array = [];
-    expect(array).toEqual([]);
+    expect(array, 'to equal', []);
 
     array[0] = 1;
-    expect(array).toEqual([1]);
+    expect(array, 'to equal', [1]);
 
     array[1] = 2;
-    expect(array).toEqual([1, FILL_ME_IN]);
+    expect(array, 'to equal', [1, FILL_ME_IN]);
 
     array.push(3);
-    expect(array).toEqual(FILL_ME_IN);
+    expect(array, 'to equal', FILL_ME_IN);
   });
 
   it("should understand array length", function () {
     var fourNumberArray = [1, 2, 3, 4];
 
-    expect(fourNumberArray.length).toBe(FILL_ME_IN);
+    expect(fourNumberArray.length, 'to be', FILL_ME_IN);
     fourNumberArray.push(5, 6);
-    expect(fourNumberArray.length).toBe(FILL_ME_IN);
+    expect(fourNumberArray.length, 'to be', FILL_ME_IN);
 
     var tenEmptyElementArray = new Array(10);
-    expect(tenEmptyElementArray.length).toBe(FILL_ME_IN);
+    expect(tenEmptyElementArray.length, 'to be', FILL_ME_IN);
 
     tenEmptyElementArray.length = 5;
-    expect(tenEmptyElementArray.length).toBe(FILL_ME_IN);
+    expect(tenEmptyElementArray.length, 'to be', FILL_ME_IN);
   });
 
   it("should slice arrays", function () {
     var array = ["peanut", "butter", "and", "jelly"];
 
-    expect(array.slice(0, 1)).toEqual(FILL_ME_IN);
-    expect(array.slice(0, 2)).toEqual(FILL_ME_IN);
-    expect(array.slice(2, 2)).toEqual(FILL_ME_IN);
-    expect(array.slice(2, 20)).toEqual(FILL_ME_IN);
-    expect(array.slice(3, 0)).toEqual(FILL_ME_IN);
-    expect(array.slice(3, 100)).toEqual(FILL_ME_IN);
-    expect(array.slice(5, 1)).toEqual(FILL_ME_IN);
+    expect(array.slice(0, 1), 'to equal', FILL_ME_IN);
+    expect(array.slice(0, 2), 'to equal', FILL_ME_IN);
+    expect(array.slice(2, 2), 'to equal', FILL_ME_IN);
+    expect(array.slice(2, 20), 'to equal', FILL_ME_IN);
+    expect(array.slice(3, 0), 'to equal', FILL_ME_IN);
+    expect(array.slice(3, 100), 'to equal', FILL_ME_IN);
+    expect(array.slice(5, 1), 'to equal', FILL_ME_IN);
   });
 
   it("should know array references", function () {
@@ -62,36 +62,36 @@ describe("About Arrays", function() {
         refArray[1] = "changed in function";
     }
     passedByReference(array);
-    expect(array[1]).toBe(FILL_ME_IN);
+    expect(array[1], 'to be', FILL_ME_IN);
 
     var assignedArray = array;
     assignedArray[5] = "changed in assignedArray";
-    expect(array[5]).toBe(FILL_ME_IN);
+    expect(array[5], 'to be', FILL_ME_IN);
 
     var copyOfArray = array.slice();
     copyOfArray[3] = "changed in copyOfArray";
-    expect(array[3]).toBe(FILL_ME_IN);
+    expect(array[3], 'to be', FILL_ME_IN);
   });
 
   it("should push and pop", function () {
     var array = [1, 2];
     array.push(3);
 
-    expect(array).toEqual(FILL_ME_IN);
+    expect(array, 'to equal', FILL_ME_IN);
 
     var poppedValue = array.pop();
-    expect(poppedValue).toBe(FILL_ME_IN);
-    expect(array).toEqual(FILL_ME_IN);
+    expect(poppedValue, 'to be', FILL_ME_IN);
+    expect(array, 'to equal', FILL_ME_IN);
   });
 
   it("should know about shifting arrays", function () {
     var array = [1, 2];
 
     array.unshift(3);
-    expect(array).toEqual(FILL_ME_IN);
+    expect(array, 'to equal', FILL_ME_IN);
 
     var shiftedValue = array.shift();
-    expect(shiftedValue).toEqual(FILL_ME_IN);
-    expect(array).toEqual(FILL_ME_IN);
+    expect(shiftedValue, 'to equal', FILL_ME_IN);
+    expect(array, 'to equal', FILL_ME_IN);
   });
 });

--- a/koans/AboutExpects.js
+++ b/koans/AboutExpects.js
@@ -2,7 +2,7 @@ describe("About Expects", function() {
 
   // We shall contemplate truth by testing reality, via spec expectations.
   it("should expect true", function() {
-    expect(false).toBeTruthy(); //This should be true
+    expect(false, 'to be truthy'); //This should be true
   });
 
   // To understand reality, we must compare our expectations against reality.
@@ -10,7 +10,7 @@ describe("About Expects", function() {
     var expectedValue = FILL_ME_IN;
     var actualValue = 1 + 1;
 
-    expect(actualValue === expectedValue).toBeTruthy();
+    expect(actualValue === expectedValue, 'to be truthy');
   });
 
   // Some ways of asserting equality are better than others.
@@ -18,8 +18,8 @@ describe("About Expects", function() {
     var expectedValue = FILL_ME_IN;
     var actualValue = 1 + 1;
 
-  // toEqual() compares using common sense equality.
-    expect(actualValue).toEqual(expectedValue);
+    // to equal compares using common sense equality.
+    expect(actualValue, 'to equal', expectedValue);
   });
 
   // Sometimes you need to be really exact about what you "type."
@@ -27,12 +27,12 @@ describe("About Expects", function() {
     var expectedValue = FILL_ME_IN;
     var actualValue = (1 + 1).toString();
 
-  // toBe() will always use === to compare.
-    expect(actualValue).toBe(expectedValue);
+    // to be will always use === to compare.
+    expect(actualValue, 'to be', expectedValue);
   });
 
   // Sometimes we will ask you to fill in the values.
   it("should have filled in values", function () {
-    expect(1 + 1).toEqual(FILL_ME_IN);
+    expect(1 + 1, 'to equal', FILL_ME_IN);
   });
 });

--- a/koans/AboutFunctions.js
+++ b/koans/AboutFunctions.js
@@ -6,7 +6,7 @@ describe("About Functions", function() {
       return a + b;
     }
 
-    expect(add(1, 2)).toBe(FILL_ME_IN);
+    expect(add(1, 2), 'to be', FILL_ME_IN);
   });
 
   it("should know internal variables override outer variables", function () {
@@ -21,9 +21,9 @@ describe("About Functions", function() {
       return message;
     }
 
-    expect(getMessage()).toBe(FILL_ME_IN);
-    expect(overrideMessage()).toBe(FILL_ME_IN);
-    expect(message).toBe(FILL_ME_IN);
+    expect(getMessage(), 'to be', FILL_ME_IN);
+    expect(overrideMessage(), 'to be', FILL_ME_IN);
+    expect(message, 'to be', FILL_ME_IN);
   });
 
   it("should have lexical scoping", function () {
@@ -35,7 +35,7 @@ describe("About Functions", function() {
       }
       return childfunction();
     }
-    expect(parentfunction()).toBe(FILL_ME_IN);
+    expect(parentfunction(), 'to be', FILL_ME_IN);
   });
 
   it("should use lexical scoping to synthesise functions", function () {
@@ -52,7 +52,7 @@ describe("About Functions", function() {
     var mysteryFunction3 = makeMysteryFunction(3);
     var mysteryFunction5 = makeMysteryFunction(5);
 
-    expect(mysteryFunction3(10) + mysteryFunction5(5)).toBe(FILL_ME_IN);
+    expect(mysteryFunction3(10) + mysteryFunction5(5), 'to be', FILL_ME_IN);
   });
 
   it("should allow extra function arguments", function () {
@@ -61,13 +61,13 @@ describe("About Functions", function() {
       return firstArg;
     }
 
-    expect(returnFirstArg("first", "second", "third")).toBe(FILL_ME_IN);
+    expect(returnFirstArg("first", "second", "third"), 'to be', FILL_ME_IN);
 
     function returnSecondArg(firstArg, secondArg) {
       return secondArg;
     }
 
-    expect(returnSecondArg("only give first arg")).toBe(FILL_ME_IN);
+    expect(returnSecondArg("only give first arg"), 'to be', FILL_ME_IN);
 
     function returnAllArgs() {
       var argsArray = [];
@@ -77,7 +77,7 @@ describe("About Functions", function() {
       return argsArray.join(",");
     }
 
-    expect(returnAllArgs("first", "second", "third")).toBe(FILL_ME_IN);
+    expect(returnAllArgs("first", "second", "third"), 'to be', FILL_ME_IN);
   });
 
   it("should pass functions as values", function () {
@@ -91,10 +91,10 @@ describe("About Functions", function() {
     };
 
     var praiseSinger = { givePraise: appendRules };
-    expect(praiseSinger.givePraise("John")).toBe(FILL_ME_IN);
+    expect(praiseSinger.givePraise("John"), 'to be', FILL_ME_IN);
 
     praiseSinger.givePraise = appendDoubleRules;
-    expect(praiseSinger.givePraise("Mary")).toBe(FILL_ME_IN);
+    expect(praiseSinger.givePraise("Mary"), 'to be', FILL_ME_IN);
 
   });
 });

--- a/koans/AboutHigherOrderFunctions.js
+++ b/koans/AboutHigherOrderFunctions.js
@@ -11,17 +11,17 @@ describe("About Higher Order Functions", function () {
     var numbers = [1,2,3];
     var odd = _(numbers).filter(function (x) { return x % 2 !== 0 });
 
-    expect(odd).toEqual(FILL_ME_IN);
-    expect(odd.length).toBe(FILL_ME_IN);
-    expect(numbers.length).toBe(FILL_ME_IN);
+    expect(odd, 'to equal', FILL_ME_IN);
+    expect(odd.length, 'to be', FILL_ME_IN);
+    expect(numbers.length, 'to be', FILL_ME_IN);
   });
 
   it("should use 'map' to transform each element", function () {
     var numbers = [1, 2, 3];
     var numbersPlus1 = _(numbers).map(function(x) { return x + 1 });
 
-    expect(numbersPlus1).toEqual(FILL_ME_IN);
-    expect(numbers).toEqual(FILL_ME_IN);
+    expect(numbersPlus1, 'to equal', FILL_ME_IN);
+    expect(numbers, 'to equal', FILL_ME_IN);
   });
 
   it("should use 'reduce' to update the same result on each iteration", function () {
@@ -29,8 +29,8 @@ describe("About Higher Order Functions", function () {
     var reduction = _(numbers).reduce(
             function(/* result from last call */ memo, /* current */ x) { return memo + x }, /* initial */ 0);
 
-    expect(reduction).toBe(FILL_ME_IN);
-    expect(numbers).toEqual(FILL_ME_IN);
+    expect(reduction, 'to be', FILL_ME_IN);
+    expect(numbers, 'to equal', FILL_ME_IN);
   });
 
   it("should use 'forEach' for simple iteration", function () {
@@ -42,8 +42,8 @@ describe("About Higher Order Functions", function () {
 
     _(numbers).forEach(isEven);
 
-    expect(msg).toEqual(FILL_ME_IN);
-    expect(numbers).toEqual(FILL_ME_IN);
+    expect(msg, 'to equal', FILL_ME_IN);
+    expect(numbers, 'to equal', FILL_ME_IN);
   });
 
   it("should use 'all' to test whether all items pass condition", function () {
@@ -52,8 +52,8 @@ describe("About Higher Order Functions", function () {
 
     var isEven = function(x) { return x % 2 === 0 };
 
-    expect(_(onlyEven).all(isEven)).toBe(FILL_ME_IN);
-    expect(_(mixedBag).all(isEven)).toBe(FILL_ME_IN);
+    expect(_(onlyEven).all(isEven), 'to be', FILL_ME_IN);
+    expect(_(mixedBag).all(isEven), 'to be', FILL_ME_IN);
   });
 
   it("should use 'any' to test if any items passes condition" , function () {
@@ -62,18 +62,18 @@ describe("About Higher Order Functions", function () {
 
     var isEven = function(x) { return x % 2 === 0 };
 
-    expect(_(onlyEven).any(isEven)).toBe(FILL_ME_IN);
-    expect(_(mixedBag).any(isEven)).toBe(FILL_ME_IN);
+    expect(_(onlyEven).any(isEven), 'to be', FILL_ME_IN);
+    expect(_(mixedBag).any(isEven), 'to be', FILL_ME_IN);
   });
 
   it("should use range to generate an array", function() {
-      expect(_.range(3)).toEqual(FILL_ME_IN);
-      expect(_.range(1, 4)).toEqual(FILL_ME_IN);
-      expect(_.range(0, -4, -1)).toEqual(FILL_ME_IN);
+      expect(_.range(3), 'to equal', FILL_ME_IN);
+      expect(_.range(1, 4), 'to equal', FILL_ME_IN);
+      expect(_.range(0, -4, -1), 'to equal', FILL_ME_IN);
   });
 
   it("should use flatten to make nested arrays easy to work with", function() {
-      expect(_([ [1, 2], [3, 4] ]).flatten()).toEqual(FILL_ME_IN);
+      expect(_([ [1, 2], [3, 4] ]).flatten(), 'to equal', FILL_ME_IN);
   });
 
   it("should use chain() ... .value() to use multiple higher order functions", function() {
@@ -83,7 +83,7 @@ describe("About Higher Order Functions", function () {
                        .reduce(function (sum, x) { return sum + x })
                        .value();
 
-      expect(result).toEqual(FILL_ME_IN);
+      expect(result, 'to equal', FILL_ME_IN);
   });
 
 });

--- a/koans/AboutInheritance.js
+++ b/koans/AboutInheritance.js
@@ -25,20 +25,20 @@ describe("About inheritance", function() {
   });
 
   it("should be able to call a method on the derived object", function() {
-    expect(this.swedishChef.cook()).toEqual(FILL_ME_IN);
+    expect(this.swedishChef.cook(), 'to equal', FILL_ME_IN);
   });
 
   it("should be able to call a method on the base object", function() {
-    expect(this.swedishChef.answerNanny()).toEqual(FILL_ME_IN);
+    expect(this.swedishChef.answerNanny(), 'to equal', FILL_ME_IN);
   });
 
   it("should set constructor parameters on the base object", function() {
-    expect(this.swedishChef.age).toEqual(FILL_ME_IN);
-    expect(this.swedishChef.hobby).toEqual(FILL_ME_IN);
+    expect(this.swedishChef.age, 'to equal', FILL_ME_IN);
+    expect(this.swedishChef.hobby, 'to equal', FILL_ME_IN);
   });
 
   it("should set constructor parameters on the derived object", function() {
-    expect(this.swedishChef.mood).toEqual(FILL_ME_IN);
+    expect(this.swedishChef.mood, 'to equal', FILL_ME_IN);
   });
 });
 
@@ -67,19 +67,19 @@ describe("About Crockford's inheritance improvement", function() {
   });
 
   it("should be able to call a method on the derived object", function() {
-    expect(this.gonzo.doTrick()).toEqual(FILL_ME_IN);
+    expect(this.gonzo.doTrick(), 'to equal', FILL_ME_IN);
   });
 
   it("should be able to call a method on the base object", function() {
-    expect(this.gonzo.answerNanny()).toEqual(FILL_ME_IN);
+    expect(this.gonzo.answerNanny(), 'to equal', FILL_ME_IN);
   });
 
   it("should set constructor parameters on the base object", function() {
-    expect(this.gonzo.age).toEqual(FILL_ME_IN);
-    expect(this.gonzo.hobby).toEqual(FILL_ME_IN);
+    expect(this.gonzo.age, 'to equal', FILL_ME_IN);
+    expect(this.gonzo.hobby, 'to equal', FILL_ME_IN);
   });
 
   it("should set constructor parameters on the derived object", function() {
-    expect(this.gonzo.trick).toEqual(FILL_ME_IN);
+    expect(this.gonzo.trick, 'to equal', FILL_ME_IN);
   });
 });

--- a/koans/AboutMutability.js
+++ b/koans/AboutMutability.js
@@ -4,7 +4,7 @@ describe("About Mutability", function() {
     var aPerson = {firstname: "John", lastname: "Smith" };
     aPerson.firstname = "Alan";
 
-    expect(aPerson.firstname).toBe(FILL_ME_IN);
+    expect(aPerson.firstname, 'to be', FILL_ME_IN);
   });
 
   it("should understand that constructed properties are public and mutable", function () {
@@ -16,7 +16,7 @@ describe("About Mutability", function() {
     var aPerson = new Person ("John", "Smith");
     aPerson.firstname = "Alan";
 
-    expect(aPerson.firstname).toBe(FILL_ME_IN);
+    expect(aPerson.firstname, 'to be', FILL_ME_IN);
   });
 
   it("should expect prototype properties to be public and mutable", function () {
@@ -30,13 +30,13 @@ describe("About Mutability", function() {
     };
 
     var aPerson = new Person ("John", "Smith");
-    expect(aPerson.getFullName()).toBe(FILL_ME_IN);
+    expect(aPerson.getFullName(), 'to be', FILL_ME_IN);
 
     aPerson.getFullName = function () {
       return this.lastname + ", " + this.firstname;
     };
 
-    expect(aPerson.getFullName()).toBe(FILL_ME_IN);
+    expect(aPerson.getFullName(), 'to be', FILL_ME_IN);
   });
 
   it("should know that variables inside a constructor and constructor args are private", function () {
@@ -54,15 +54,15 @@ describe("About Mutability", function() {
     aPerson.lastname = "Andrews";
     aPerson.fullName = "Penny Andrews";
 
-    expect(aPerson.getFirstName()).toBe(FILL_ME_IN);
-    expect(aPerson.getLastName()).toBe(FILL_ME_IN);
-    expect(aPerson.getFullName()).toBe(FILL_ME_IN);
+    expect(aPerson.getFirstName(), 'to be', FILL_ME_IN);
+    expect(aPerson.getLastName(), 'to be', FILL_ME_IN);
+    expect(aPerson.getFullName(), 'to be', FILL_ME_IN);
 
     aPerson.getFullName = function () {
       return aPerson.lastname + ", " + aPerson.firstname;
     };
 
-    expect(aPerson.getFullName()).toBe(FILL_ME_IN);
+    expect(aPerson.getFullName(), 'to be', FILL_ME_IN);
   });
 
 });

--- a/koans/AboutObjects.js
+++ b/koans/AboutObjects.js
@@ -1,3 +1,4 @@
+
 describe("About Objects", function () {
 
   describe("Properties", function () {
@@ -8,12 +9,12 @@ describe("About Objects", function () {
     });
 
     it("should confirm objects are collections of properties", function () {
-      expect(megalomaniac.mastermind).toBe(FILL_ME_IN);
+      expect(megalomaniac.mastermind, 'to be', FILL_ME_IN);
     });
 
     it("should confirm that properties are case sensitive", function () {
-      expect(megalomaniac.henchwoman).toBe(FILL_ME_IN);
-      expect(megalomaniac.henchWoman).toBe(FILL_ME_IN);
+      expect(megalomaniac.henchwoman, 'to be', FILL_ME_IN);
+      expect(megalomaniac.henchWoman, 'to be', FILL_ME_IN);
     });
   });
 
@@ -29,7 +30,7 @@ describe("About Objects", function () {
     };
 
     var battleCry = megalomaniac.battleCry(4);
-    expect(FILL_ME_IN).toMatch(battleCry);
+    expect(FILL_ME_IN, 'to match', battleCry);
   });
 
   it("should confirm that when a function is attached to an object, 'this' refers to the object", function () {
@@ -44,8 +45,8 @@ describe("About Objects", function () {
       }
     };
 
-    expect(currentYear).toBe(FILL_ME_IN);
-    expect(megalomaniac.calculateAge()).toBe(FILL_ME_IN);
+    expect(currentYear, 'to be', FILL_ME_IN);
+    expect(megalomaniac.calculateAge(), 'to be', FILL_ME_IN);
   });
 
   describe("'in' keyword", function () {
@@ -62,27 +63,27 @@ describe("About Objects", function () {
 
       var hasBomb = "theBomb" in megalomaniac;
 
-      expect(hasBomb).toBe(FILL_ME_IN);
+      expect(hasBomb, 'to be', FILL_ME_IN);
     });
 
     it("should not have the detonator however", function () {
 
       var hasDetonator = "theDetonator" in megalomaniac;
 
-      expect(hasDetonator).toBe(FILL_ME_IN);
+      expect(hasDetonator, 'to be', FILL_ME_IN);
     });
   });
 
   it("should know that properties can be added and deleted", function () {
     var megalomaniac = { mastermind : "Agent Smith", henchman: "Agent Smith" };
 
-    expect("secretary" in megalomaniac).toBe(FILL_ME_IN);
+    expect("secretary" in megalomaniac, 'to be', FILL_ME_IN);
 
     megalomaniac.secretary = "Agent Smith";
-    expect("secretary" in megalomaniac).toBe(FILL_ME_IN);
+    expect("secretary" in megalomaniac, 'to be', FILL_ME_IN);
 
     delete megalomaniac.henchman;
-    expect("henchman" in megalomaniac).toBe(FILL_ME_IN);
+    expect("henchman" in megalomaniac, 'to be', FILL_ME_IN);
   });
 
 
@@ -96,14 +97,14 @@ describe("About Objects", function () {
       var colouredCircle = new Circle(5);
       colouredCircle.colour = "red";
 
-      expect(simpleCircle.colour).toBe(FILL_ME_IN);
-      expect(colouredCircle.colour).toBe(FILL_ME_IN);
+      expect(simpleCircle.colour, 'to be', FILL_ME_IN);
+      expect(colouredCircle.colour, 'to be', FILL_ME_IN);
 
       Circle.prototype.describe = function () {
         return "This circle has a radius of: " + this.radius;
       };
 
-      expect(simpleCircle.describe()).toBe(FILL_ME_IN);
-      expect(colouredCircle.describe()).toBe(FILL_ME_IN);
+      expect(simpleCircle.describe(), 'to be', FILL_ME_IN);
+      expect(colouredCircle.describe(), 'to be', FILL_ME_IN);
   });
 });

--- a/lib/jasmine/jskoans-jasmine-html.js
+++ b/lib/jasmine/jskoans-jasmine-html.js
@@ -194,7 +194,7 @@ JsKoansReporter.prototype.reportSpecResults = function(spec) {
 
       if (result.trace.stack) {
         var lines = result.trace.stack.split('\n');
-        var stack = lines[0];
+        var stack = '';
         for (var i = 1; i < lines.length; i++) {
           if (lines[i].search('/koans/') != -1) {
             stack += '\n' + lines[i]

--- a/lib/jasmineHtmlMessages.js
+++ b/lib/jasmineHtmlMessages.js
@@ -1,0 +1,24 @@
+(function () {
+    var originalFail = jasmine.Spec.prototype.fail;
+    jasmine.Spec.prototype.fail = function (e) {
+        var message = (e && e.message) || 'Error';
+        var expectationResult = new jasmine.ExpectationResult({
+            passed: false,
+            message: message
+        })
+
+        if (e) {
+            if (e.htmlMessage) {
+                var errorElement = document.createElement('div');
+                errorElement.innerHTML = e.htmlMessage;
+                expectationResult.message = errorElement
+            }
+
+            expectationResult.trace = {
+                stack: e.stack.substring(e.stack.indexOf(message) + message.length + 1)
+            };
+        }
+
+        this.results_.addResult(expectationResult);
+    }
+}());

--- a/lib/unexpected.js
+++ b/lib/unexpected.js
@@ -1,0 +1,13145 @@
+/*!
+ * Copyright (c) 2013 Sune Simonsen <sune@we-knowhow.dk>
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the 'Software'), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+!function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var o;"undefined"!=typeof window?o=window:"undefined"!=typeof global?o=global:"undefined"!=typeof self&&(o=self),(o.weknowhow||(o.weknowhow={})).expect=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+var createStandardErrorMessage = require(5);
+
+function Assertion(expect, subject, testDescription, flags, alternations, args) {
+    this.expect = expect;
+    this.subject = subject;
+    this.testDescription = testDescription;
+    this.flags = flags;
+    this.alternations = alternations;
+    this.args = args;
+    this.subjectOutput = function (output) {
+        output.appendInspected(subject);
+    };
+    this.argsOutput = this.args.map(function (arg) {
+        return function (output) {
+            output.appendInspected(arg);
+        };
+    });
+    this.errorMode = 'default';
+}
+
+Assertion.prototype.standardErrorMessage = function (output, options) {
+    if (options && options.compact) {
+        var expect = this.expect;
+        var subject = this.subject;
+        options.compactSubject = function (output) {
+            var subjectType = expect.findTypeOf(subject);
+            output.jsFunctionName(subjectType.name);
+        };
+    }
+
+    return createStandardErrorMessage(output, this.expect, this.subjectOutput, this.testDescription, this.argsOutput, options);
+};
+
+Assertion.prototype.shift = function (subject, assertionIndex) {
+    var expect = this.expect;
+    if (arguments.length === 3) {
+        // The 3-argument syntax for Assertion.prototype.shift is deprecated, please omit the first (expect) arg
+        subject = arguments[1];
+        assertionIndex = arguments[2];
+    }
+
+    var args = this.args.slice(0, assertionIndex);
+    var rest = this.args.slice(assertionIndex);
+    var nextArgumentType = expect.findTypeOf(rest[0]);
+    this.argsOutput = function (output) {
+        args.forEach(function (arg, index) {
+            if (0 < index) {
+                output.text(', ');
+            }
+            output.appendInspected(arg);
+        });
+
+        if (args.length > 0) {
+            output.sp();
+        }
+        if (nextArgumentType.is('string')) {
+            output.error(rest[0]);
+        } else {
+            output.appendInspected(rest[0]);
+        }
+        if (rest.length > 1) {
+            output.sp();
+        }
+        rest.slice(1).forEach(function (arg, index) {
+            if (0 < index) {
+                output.text(', ');
+            }
+            output.appendInspected(arg);
+        });
+    };
+    if (nextArgumentType.is('expect.it')) {
+        return rest[0](subject);
+    } else if (nextArgumentType.is('string')) {
+        return expect.apply(expect, [subject].concat(rest));
+    } else {
+        throw new Error('The "' + this.testDescription + '" assertion requires parameter #' + (assertionIndex + 2) + ' to be an expect.it function or a string specifying an assertion to delegate to');
+    }
+};
+
+module.exports = Assertion;
+
+},{}],2:[function(require,module,exports){
+var Assertion = require(1);
+var createStandardErrorMessage = require(5);
+var utils = require(13);
+var magicpen = require(29);
+var extend = utils.extend;
+var leven = require(25);
+var makePromise = require(7);
+var isPendingPromise = require(6);
+var oathbreaker = require(8);
+var throwIfNonUnexpectedError = require(11);
+var UnexpectedError = require(3);
+var testFrameworkPatch = require(10);
+
+var anyType = {
+    name: 'any',
+    identify: function () {
+        return true;
+    },
+    equal: utils.objectIs,
+    inspect: function (value, depth, output) {
+        if (output && output.isMagicPen) {
+            return output.text(value);
+        } else {
+            // Guard against node.js' require('util').inspect eagerly calling .inspect() on objects
+            return String(value);
+        }
+    },
+    diff: function (actual, expected, output, diff, inspect) {
+        return null;
+    },
+    is: function (typeOrTypeName) {
+        var typeName;
+        if (typeof typeOrTypeName === 'string') {
+            typeName = typeOrTypeName;
+        } else {
+            typeName = typeOrTypeName.name;
+        }
+        if (this.name === typeName) {
+            return true;
+        } else if (this.baseType) {
+            return this.baseType.is(typeName);
+        } else {
+            return false;
+        }
+    }
+};
+
+
+function Unexpected(options) {
+    testFrameworkPatch.applyPatch();
+    options = options || {};
+    this.assertions = options.assertions || {any: {}};
+    this.typeByName = options.typeByName || {};
+    this.types = options.types || [anyType];
+    this.output = options.output || magicpen();
+    this._outputFormat = options.format || magicpen.defaultFormat;
+    this.installedPlugins = options.installedPlugins || [];
+
+    // Make bound versions of these two helpers up front to save a bit when creating wrapped expects:
+    var that = this;
+    this.getType = function (typeName) {
+        return utils.findFirst(that.types, function (type) {
+            return type.name === typeName;
+        });
+    };
+    this.findTypeOf = function (obj) {
+        return utils.findFirst(that.types || [], function (type) {
+            return type.identify(obj);
+        });
+    };
+    this.findCommonType = function (a, b) {
+        var aAncestorIndex = {};
+        var current = this.findTypeOf(a);
+        while (current) {
+            aAncestorIndex[current.name] = current;
+            current = current.baseType;
+        }
+        current = this.findTypeOf(b);
+        while (current) {
+            if (aAncestorIndex[current.name]) {
+                return current;
+            }
+            current = current.baseType;
+        }
+    };
+}
+
+var OR = {};
+function getOrGroups(expectations) {
+    var orGroups = [[]];
+    expectations.forEach(function (expectation) {
+        if (expectation === OR) {
+            orGroups.push([]);
+        } else {
+            orGroups[orGroups.length - 1].push(expectation);
+        }
+    });
+    return orGroups;
+}
+
+function evaluateGroup(expect, subject, orGroup) {
+    return orGroup.map(function (expectation) {
+        var args = Array.prototype.slice.call(expectation);
+        args.unshift(subject);
+        return {
+            expectation: args,
+            promise: makePromise(function () {
+                return expect.apply(expect, args);
+            })
+        };
+    });
+}
+
+function writeGroupEvaluationsToOutput(expect, output, groupEvaluations) {
+    var hasOrClauses = groupEvaluations.length > 1;
+    var hasAndClauses = groupEvaluations.some(function (groupEvaluation) {
+        return groupEvaluation.length > 1;
+    });
+    groupEvaluations.forEach(function (groupEvaluation, i) {
+        if (i > 0) {
+            if (hasAndClauses) {
+                output.nl();
+            } else {
+                output.sp();
+            }
+            output.jsComment('or').nl();
+        }
+
+        var groupFailed = false;
+        groupEvaluation.forEach(function (evaluation, j) {
+            if (j > 0) {
+                output.jsComment(' and').nl();
+            }
+            var isRejected = evaluation.promise.isRejected();
+            if (isRejected && !groupFailed) {
+                groupFailed = true;
+                var err = evaluation.promise.reason();
+
+                if (hasAndClauses || hasOrClauses) {
+                    output.error('⨯ ');
+                }
+
+                output.block(function (output) {
+                    output.append(err.getErrorMessage(output));
+                });
+            } else {
+                var style;
+                if (isRejected) {
+                    style = 'error';
+                    output.error('⨯ ');
+                } else {
+                    style = 'success';
+                    output.success('✓ ');
+                }
+
+                var expectation = evaluation.expectation;
+                output.block(function (output) {
+                    output[style]('expected ');
+                    output.appendInspected(expectation[0]).sp();
+                    output[style](expectation[1]);
+                    expectation.slice(2).forEach(function (v) {
+                        output.sp().appendInspected(v);
+                    });
+                });
+            }
+        });
+    });
+}
+
+function createExpectIt(expect, expectations) {
+    var orGroups = getOrGroups(expectations);
+
+    function expectIt(subject) {
+        var groupEvaluations = [];
+        var promises = [];
+        orGroups.forEach(function (orGroup) {
+            var evaluations = evaluateGroup(expect, subject, orGroup);
+            evaluations.forEach(function (evaluation) {
+                promises.push(evaluation.promise);
+            });
+            groupEvaluations.push(evaluations);
+        });
+
+        return oathbreaker(expect.promise.settle(promises).then(function () {
+            var isSuccessful = groupEvaluations.some(function (groupEvaluation) {
+                return groupEvaluation.every(function (evaluation) {
+                    return evaluation.promise.isFulfilled();
+                });
+            });
+
+            if (!isSuccessful) {
+                expect.fail(function (output) {
+                    writeGroupEvaluationsToOutput(expect, output, groupEvaluations);
+                });
+            }
+        }));
+    }
+    expectIt._expectIt = true;
+    expectIt._expectations = expectations;
+    expectIt._OR = OR;
+    expectIt.and = function () {
+        var copiedExpectations = expectations.slice();
+        copiedExpectations.push(arguments);
+        return createExpectIt(expect, copiedExpectations);
+    };
+    expectIt.or = function () {
+        var copiedExpectations = expectations.slice();
+        copiedExpectations.push(OR, arguments);
+        return createExpectIt(expect, copiedExpectations);
+    };
+    return expectIt;
+}
+
+Unexpected.prototype.it = function () { // ...
+    return createExpectIt(this.expect, [arguments]);
+};
+
+Unexpected.prototype.equal = function (actual, expected, depth, seen) {
+    var that = this;
+
+    depth = typeof depth === 'number' ? depth : 100;
+    if (depth <= 0) {
+        // detect recursive loops in the structure
+        seen = seen || [];
+        if (seen.indexOf(actual) !== -1) {
+            throw new Error('Cannot compare circular structures');
+        }
+        seen.push(actual);
+    }
+
+    return this.findCommonType(actual, expected).equal(actual, expected, function (a, b) {
+        return that.equal(a, b, depth - 1, seen);
+    });
+};
+
+Unexpected.prototype.inspect = function (obj, depth, output) {
+    var seen = [];
+    var that = this;
+    var printOutput = function (obj, currentDepth, output) {
+        var objType = that.findTypeOf(obj);
+        if (currentDepth === 0 && objType.is('object') && !objType.is('expect.it')) {
+            return output.text('...');
+        }
+
+        seen = seen || [];
+        if (seen.indexOf(obj) !== -1) {
+            return output.text('[Circular]');
+        }
+
+        return objType.inspect(obj, currentDepth, output, function (v, childDepth) {
+            output = output.clone();
+            seen.push(obj);
+            if (typeof childDepth === 'undefined') {
+                childDepth = currentDepth - 1;
+            }
+            return printOutput(v, childDepth, output) || output;
+        });
+    };
+
+    output = output || this.createOutput();
+    return printOutput(obj, depth || 3, output) || output;
+};
+
+var placeholderSplitRegexp = /(\{(?:\d+)\})/g;
+var placeholderRegexp = /\{(\d+)\}/;
+Unexpected.prototype.fail = function (arg) {
+    if (arg instanceof UnexpectedError) {
+        arg._hasSerializedErrorMessage = false;
+        throw arg;
+    }
+
+    if (utils.isError(arg)) {
+        throw arg;
+    }
+
+    var error = new UnexpectedError(this.expect);
+
+    if (typeof arg === 'function') {
+        error.output = arg;
+    } else if (arg && typeof arg === 'object') {
+        error.output = function (output) {
+            if (typeof arg.message !== 'undefined') {
+                if (arg.message.isMagicPen) {
+                    output.append(arg.message);
+                } else if (typeof arg.message === 'function') {
+                    arg.message.call(output, output);
+                } else {
+                    output.text(String(arg.message));
+                }
+            } else {
+                output.error('Explicit failure');
+            }
+        };
+        var additionalProperties = {};
+        if (arg && typeof arg === 'object') {
+            Object.keys(arg).forEach(function (key) {
+                var value = arg[key];
+                if (key === 'diff') {
+                    additionalProperties.createDiff = value;
+                } else if (key !== 'message') {
+                    additionalProperties[key] = value;
+                }
+            });
+        }
+
+        Object.keys(additionalProperties).forEach(function (key) {
+            error[key] = additionalProperties[key];
+        });
+    } else {
+        var placeholderArgs = Array.prototype.slice.call(arguments, 1);
+        error.output = function (output) {
+            var message = arg ? String(arg) : 'Explicit failure';
+            var tokens = message.split(placeholderSplitRegexp);
+            tokens.forEach(function (token) {
+                var match = placeholderRegexp.exec(token);
+                if (match) {
+                    var index = match[1];
+                    if (index in placeholderArgs) {
+                        var placeholderArg = placeholderArgs[index];
+                        if (placeholderArg && placeholderArg.isMagicPen) {
+                            output.append(placeholderArg);
+                        } else {
+                            output.appendInspected(placeholderArg);
+                        }
+                    } else {
+                        output.text(match[0]);
+                    }
+
+                } else {
+                    output.error(token);
+                }
+            });
+        };
+    }
+
+    throw error;
+};
+
+// addAssertion(pattern, handler)
+// addAssertion([pattern, ...]], handler)
+// addAssertion(typeName, pattern, handler)
+// addAssertion([typeName, ...], pattern, handler)
+// addAssertion([typeName, ...], [pattern, pattern...], handler)
+Unexpected.prototype.addAssertion = function (types, patterns, handler) {
+    if (arguments.length !== 2 && arguments.length !== 3) {
+        throw new Error('addAssertion: Needs 2 or 3 arguments');
+    }
+    if (typeof patterns === 'function') {
+        handler = patterns;
+        patterns = types;
+        types = [anyType];
+    } else {
+        var typeByName = this.typeByName;
+        // Normalize to an array of types, but allow types to be specified by name:
+        types = (Array.isArray(types) ? types : [types]).map(function (type) {
+            if (typeof type === 'string') {
+                if (type in typeByName) {
+                    return typeByName[type];
+                } else {
+                    throw new Error('No such type: ' + type);
+                }
+            } else {
+                return type;
+            }
+        });
+    }
+    patterns = utils.isArray(patterns) ? patterns : [patterns];
+    var assertions = this.assertions;
+    types.forEach(function (type) {
+        var typeName = type.name;
+        var assertionsForType = assertions[typeName];
+        if (!assertionsForType) {
+            throw new Error('No such type: ' + typeName);
+        }
+        var isSeenByExpandedPattern = {};
+        patterns.forEach(ensureValidPattern);
+        var expandedPatternArrays = patterns.map(expandPattern);
+        var defaultValueByFlag = {};
+        expandedPatternArrays.forEach(function(expandedPatterns) {
+            expandedPatterns.forEach(function (expandedPattern) {
+                Object.keys(expandedPattern.flags).forEach(function (flag) {
+                    defaultValueByFlag[flag] = false;
+                });
+            });
+        });
+        patterns.forEach(function (pattern, i) {
+            expandedPatternArrays[i].forEach(function (expandedPattern) {
+                if (expandedPattern.text in assertionsForType) {
+                    if (!isSeenByExpandedPattern[expandedPattern.text]) {
+                        throw new Error('Cannot redefine assertion: ' + expandedPattern.text + (typeName === 'any' ? '' : ' for type ' + typeName));
+                    }
+                } else {
+                    isSeenByExpandedPattern[expandedPattern.text] = true;
+                    assertionsForType[expandedPattern.text] = {
+                        handler: handler,
+                        flags: extend({}, defaultValueByFlag, expandedPattern.flags),
+                        alternations: expandedPattern.alternations
+                    };
+                }
+            });
+        });
+    });
+
+    return this.expect; // for chaining
+};
+
+Unexpected.prototype.addType = function (type) {
+    var that = this;
+    var baseType;
+    if (typeof type.name !== 'string' || !/^[a-z_](?:|[a-z0-9_.-]*[_a-z0-9])$/i.test(type.name)) {
+        throw new Error('A type must be given a non-empty name and must match ^[a-z_](?:|[a-z0-9_.-]*[_a-z0-9])$');
+    }
+
+    if (this.getType(type.name)) {
+        throw new Error('The type with the name ' + type.name + ' already exists');
+    }
+
+    this.assertions[type.name] = {};
+    this.typeByName[type.name] = type;
+
+    if (type.base) {
+        baseType = utils.findFirst(this.types, function (t) {
+            return t.name === type.base;
+        });
+
+        if (!baseType) {
+            throw new Error('Unknown base type: ' + type.base);
+        }
+    } else {
+        baseType = anyType;
+    }
+
+    var extendedBaseType = Object.create(baseType);
+    extendedBaseType.inspect = function (value, depth, output) {
+        if (!output || !output.isMagicPen) {
+            throw new Error('You need to pass the output to baseType.inspect() as the third parameter');
+        }
+
+        return baseType.inspect(value, depth, output.clone(), function (value, depth) {
+            return output.clone().appendInspected(value, depth);
+        });
+    };
+
+    extendedBaseType.diff = function (actual, expected, output) {
+        if (!output || !output.isMagicPen) {
+            throw new Error('You need to pass the output to baseType.diff() as the third parameter');
+        }
+
+        return baseType.diff(actual, expected,
+                      output.clone(),
+                      function (actual, expected) {
+                          return that.diff(actual, expected, output.clone());
+                      },
+                      function (value, depth) {
+                          return output.clone().appendInspected(value, depth);
+                      },
+                      that.equal.bind(that));
+    };
+
+    extendedBaseType.equal = function (actual, expected) {
+        return baseType.equal(actual, expected, that.equal.bind(that));
+    };
+
+    var extendedType = extend({}, baseType, type, { baseType: extendedBaseType });
+    var inspect = extendedType.inspect;
+
+    extendedType.inspect = function () {
+        if (arguments.length < 2) {
+            return 'type: ' + type.name;
+        } else {
+            return inspect.apply(this, arguments);
+        }
+    };
+    if (extendedType.identify === false) {
+        extendedType.identify = function () {
+            return false;
+        };
+        this.types.push(extendedType);
+    } else {
+        this.types.unshift(extendedType);
+    }
+
+    return this.expect;
+};
+
+Unexpected.prototype.addStyle = function () { // ...
+    return this.output.addStyle.apply(this.output, arguments);
+};
+
+Unexpected.prototype.installTheme = function () { // ...
+    return this.output.installTheme.apply(this.output, arguments);
+};
+
+Unexpected.prototype.use = function (plugin) {
+    var existingPlugin = utils.findFirst(this.installedPlugins, function (installedPlugin) {
+        if (installedPlugin === plugin) {
+            return true;
+        } else if (typeof plugin === 'function' && typeof installedPlugin === 'function') {
+            var pluginName = utils.getFunctionName(plugin);
+            return pluginName !== '' && pluginName === utils.getFunctionName(installedPlugin);
+        } else {
+            return installedPlugin.name === plugin.name;
+        }
+    });
+
+    if (existingPlugin) {
+        if (existingPlugin === plugin) {
+            // No-op
+            return this.expect;
+        } else {
+            throw new Error("Another instance of the plugin '" + plugin.name + "' is already installed. " +
+                            "Please check your node_modules folder for unmet peerDependencies.");
+        }
+    }
+
+    if ((typeof plugin !== 'function' && (typeof plugin !== 'object' || typeof plugin.installInto !== 'function')) ||
+        (typeof plugin.name !== 'undefined' && typeof plugin.name !== 'string') ||
+        (typeof plugin.dependencies !== 'undefined' && !Array.isArray(plugin.dependencies))) {
+        throw new Error('Plugins must be functions or adhere to the following interface\n' +
+                        '{\n' +
+                        '  name: <an optional plugin name>,\n' +
+                        '  dependencies: <an optional list of dependencies>,\n' +
+                        '  installInto: <a function that will update the given expect instance>\n' +
+                        '}');
+    }
+
+    if (plugin.name === 'unexpected-promise') {
+        throw new Error('The unexpected-promise plugin was pulled into Unexpected as of 8.5.0. This means that the plugin is no longer supported.');
+    }
+
+    if (plugin.dependencies) {
+        var installedPlugins = this.installedPlugins;
+        var unfulfilledDependencies = plugin.dependencies.filter(function (dependency) {
+            return !installedPlugins.some(function (plugin) {
+                return plugin.name === dependency;
+            });
+        });
+
+        if (unfulfilledDependencies.length === 1) {
+            throw new Error(plugin.name + ' requires plugin ' + unfulfilledDependencies[0]);
+        } else if (unfulfilledDependencies.length > 1) {
+            throw new Error(plugin.name + ' requires plugins ' +
+                            unfulfilledDependencies.slice(0, -1).join(', ') +
+                            ' and ' + unfulfilledDependencies[unfulfilledDependencies.length - 1]);
+        }
+    }
+
+    this.installedPlugins.push(plugin);
+    if (typeof plugin === 'function') {
+        plugin(this.expect);
+    } else {
+        plugin.installInto(this.expect);
+    }
+
+    return this.expect; // for chaining
+};
+
+Unexpected.prototype.installPlugin = Unexpected.prototype.use; // Legacy alias
+
+function installExpectMethods(unexpected, expectFunction) {
+    var expect = expectFunction.bind(unexpected);
+    expect.it = unexpected.it.bind(unexpected);
+    expect.equal = unexpected.equal.bind(unexpected);
+    expect.inspect = unexpected.inspect.bind(unexpected);
+    expect.findTypeOf = unexpected.findTypeOf; // Already bound
+    expect.fail = function () {
+        try {
+            unexpected.fail.apply(unexpected, arguments);
+        } catch (e) {
+            if (e && e._isUnexpected) {
+                unexpected.setErrorMessage(e);
+            }
+            throw e;
+        }
+    };
+
+    expect.createOutput = unexpected.createOutput.bind(unexpected);
+    expect.diff = unexpected.diff.bind(unexpected);
+    expect.async = unexpected.async.bind(unexpected);
+    expect.promise = makePromise;
+    expect.addAssertion = unexpected.addAssertion.bind(unexpected);
+    expect.addStyle = unexpected.addStyle.bind(unexpected);
+    expect.installTheme = unexpected.installTheme.bind(unexpected);
+    expect.addType = unexpected.addType.bind(unexpected);
+    expect.getType = unexpected.getType;
+    expect.clone = unexpected.clone.bind(unexpected);
+    expect.toString = unexpected.toString.bind(unexpected);
+    expect.assertions = unexpected.assertions;
+    expect.use = expect.installPlugin = unexpected.use.bind(unexpected);
+    expect.output = unexpected.output;
+    expect.outputFormat = unexpected.outputFormat.bind(unexpected);
+    return expect;
+}
+
+function makeExpectFunction(unexpected) {
+    var expect = installExpectMethods(unexpected, unexpected.expect);
+    unexpected.expect = expect;
+    return expect;
+}
+
+Unexpected.prototype.setErrorMessage = function (err) {
+    err.serializeMessage(this.outputFormat());
+};
+
+Unexpected.prototype.toString = function () {
+    return this.message;
+};
+
+function makeAndMethod(expect, subject) {
+    return function () { // ...
+        var args = Array.prototype.slice.call(arguments);
+        function executeAnd() {
+            if (expect.findTypeOf(args[0]).is('expect.it')) {
+                return args[0](subject);
+            } else {
+                return expect.apply(expect, [subject].concat(args));
+            }
+        }
+
+        if (this.isFulfilled()) {
+            return executeAnd();
+        } else {
+            return this.then(executeAnd);
+        }
+    };
+}
+
+Unexpected.prototype.expect = function expect(subject, testDescriptionString) {
+    var that = this;
+    if (arguments.length < 2) {
+        throw new Error('The expect function requires at least two parameters.');
+    }
+
+    var serializeErrorsFromWrappedExpect = false;
+    function executeExpect(subject, testDescriptionString, args) {
+        if (typeof testDescriptionString !== 'string') {
+            throw new Error('The expect function requires the second parameter to be a string.');
+        }
+        var matchingType = that.findTypeOf(subject);
+        var typeWithAssertion = matchingType;
+        var assertionRule = that.assertions[typeWithAssertion.name][testDescriptionString];
+        while (!assertionRule && typeWithAssertion.name !== anyType.name) {
+            // FIXME: Detect cycles?
+            typeWithAssertion = typeWithAssertion.baseType;
+            assertionRule = that.assertions[typeWithAssertion.name][testDescriptionString];
+        }
+        if (assertionRule) {
+            var flags = extend({}, assertionRule.flags);
+            var callInNestedContext = function (callback) {
+                try {
+                    var result = oathbreaker(callback());
+                    if (isPendingPromise(result)) {
+                        testFrameworkPatch.promiseCreated();
+                        result = result.then(undefined, function (e) {
+                            if (e && e._isUnexpected) {
+                                throw new UnexpectedError(that.expect, assertion, e);
+                            }
+                            throw e;
+                        });
+                    } else if (!result || typeof result.then !== 'function') {
+                        result = makePromise.resolve(result);
+                    }
+                    result.and = makeAndMethod(that.expect, subject);
+                    return result;
+                } catch (e) {
+                    if (e && e._isUnexpected) {
+                        var wrappedError = new UnexpectedError(that.expect, assertion, e);
+                        if (serializeErrorsFromWrappedExpect) {
+                            that.setErrorMessage(wrappedError);
+                        }
+                        throw wrappedError;
+                    }
+                    throw e;
+                }
+            };
+
+            var wrappedExpect = function wrappedExpect() {
+                var subject = arguments[0];
+                var testDescriptionString = arguments[1].replace(/\[(!?)([^\]]+)\] ?/g, function (match, negate, flag) {
+                    return Boolean(flags[flag]) !== Boolean(negate) ? flag + ' ' : '';
+                }).trim();
+
+                var args = new Array(arguments.length - 2);
+                for (var i = 0; i < arguments.length - 2; i += 1) {
+                    args[i] = arguments[i + 2];
+                }
+                return callInNestedContext(function () {
+                    return executeExpect(subject, testDescriptionString, args);
+                });
+            };
+
+            // Not sure this is the right way to go about this:
+            wrappedExpect.equal = that.equal;
+            wrappedExpect.inspect = that.inspect;
+            wrappedExpect.createOutput = that.createOutput.bind(that);
+            wrappedExpect.diff = that.diff;
+            wrappedExpect.findTypeOf = that.findTypeOf.bind(that);
+            wrappedExpect.findCommonType = that.findCommonType.bind(that);
+            wrappedExpect.getType = that.getType;
+            wrappedExpect.output = that.output;
+            wrappedExpect.outputFormat = that.outputFormat;
+            wrappedExpect.fail = function () {
+                var args = arguments;
+                callInNestedContext(function () {
+                    that.fail.apply(that, args);
+                });
+            };
+            wrappedExpect.promise = makePromise;
+            wrappedExpect.withError = function (body, handler) {
+                return oathbreaker(makePromise(body).caught(function (e) {
+                    throwIfNonUnexpectedError(e);
+                    return handler(e);
+                }));
+            };
+
+            wrappedExpect.format = that.format;
+            wrappedExpect.it = that.it.bind(that);
+
+            var assertion = new Assertion(wrappedExpect, subject, testDescriptionString,
+                                          flags, assertionRule.alternations, args);
+            var handler = assertionRule.handler;
+            var result = handler.apply(assertion, [wrappedExpect, subject].concat(args));
+            return oathbreaker(result);
+        } else {
+            that.fail({
+                message: function (output) {
+                    var definedForIncompatibleTypes = that.types.filter(function (type) {
+                        return that.assertions[type.name][testDescriptionString];
+                    }, that);
+                    if (definedForIncompatibleTypes.length > 0) {
+                        var subjectOutput = function (output) {
+                            output.appendInspected(subject);
+                        };
+                        var argsOutput = args.map(function (arg) {
+                            return function (output) {
+                                output.appendInspected(arg);
+                            };
+                        });
+                        output
+                            .append(createStandardErrorMessage(output.clone(), that.expect, subjectOutput, testDescriptionString, argsOutput)).nl()
+                            .indentLines()
+                            .i().error("The assertion '").jsString(testDescriptionString)
+                            .error("' is not defined for the type '").jsString(matchingType.name).error("',").nl()
+                            .i().error('but it is defined for ')
+                            .outdentLines();
+                        if (definedForIncompatibleTypes.length === 1) {
+                            output.error("the type '").jsString(definedForIncompatibleTypes[0].name).error("'");
+                        } else {
+                            output.error('these types: ');
+
+                            definedForIncompatibleTypes.forEach(function (incompatibleType, index) {
+                                if (index > 0) {
+                                    output.error(', ');
+                                }
+                                output.error("'").jsString(incompatibleType.name).error("'");
+                            });
+                        }
+                    } else {
+                        var assertionsWithScore = [];
+                        var bonusForNextMatchingType = 0;
+                        [].concat(that.types).reverse().forEach(function (type) {
+                            var typeMatchBonus = 0;
+                            if (type.identify(subject)) {
+                                typeMatchBonus = bonusForNextMatchingType;
+                                bonusForNextMatchingType += 0.9;
+                            }
+                            Object.keys(that.assertions[type.name]).forEach(function (assertion) {
+                                assertionsWithScore.push({
+                                    type: type,
+                                    assertion: assertion,
+                                    score: typeMatchBonus - leven(testDescriptionString, assertion)
+                                });
+                            });
+                        }, that);
+                        assertionsWithScore.sort(function (a, b) {
+                            var c = b.score - a.score;
+                            if (c !== 0) {
+                                return c;
+                            }
+
+                            if (a.assertion < b.assertion) {
+                                return -1;
+                            } else if (a.assertion > b.assertion) {
+                                return 1;
+                            } else {
+                                return 0;
+                            }
+                        });
+                        output.error("Unknown assertion '").jsString(testDescriptionString)
+                            .error("', did you mean: '").jsString(assertionsWithScore[0].assertion).error("'");
+                    }
+                },
+                errorMode: 'bubbleThrough'
+            });
+        }
+    }
+
+    var args = Array.prototype.slice.call(arguments, 2);
+    try {
+        var result = executeExpect(subject, testDescriptionString, args);
+        if (isPendingPromise(result)) {
+            testFrameworkPatch.promiseCreated();
+            result = result.then(undefined, function (e) {
+                if (e && e._isUnexpected) {
+                    that.setErrorMessage(e);
+                }
+                throw e;
+            });
+        } else {
+            serializeErrorsFromWrappedExpect = true;
+            if (!result || typeof result.then !== 'function') {
+                result = makePromise.resolve(result);
+            }
+        }
+        result.and = makeAndMethod(that.expect, subject);
+        return result;
+    } catch (e) {
+        if (e && e._isUnexpected) {
+            var newError = e;
+            if (typeof mochaPhantomJS !== 'undefined') {
+                newError = e.clone();
+            }
+            that.setErrorMessage(newError);
+            throw newError;
+        }
+        throw e;
+    }
+};
+
+Unexpected.prototype.async = function (cb) {
+    var that = this;
+
+    function asyncMisusage(message) {
+        that._isAsync = false;
+        that.expect.fail(function (output) {
+            output.error(message).nl()
+                  .text("Usage: ").nl()
+                  .text("it('test description', expect.async(function () {").nl()
+                  .indentLines()
+                  .i().text("return expect('test.txt', 'to have content', 'Content read asynchroniously');").nl()
+                  .outdentLines()
+                  .text("});");
+        });
+    }
+
+    if (typeof cb !== 'function' || cb.length !== 0) {
+        asyncMisusage("expect.async requires a callback without arguments.");
+    }
+
+    return function (done) {
+        if (that._isAsync) {
+            asyncMisusage("expect.async can't be within a expect.async context.");
+        }
+        that._isAsync = true;
+
+        if (typeof done !== 'function') {
+            asyncMisusage("expect.async should be called in the context of an it-block\n" +
+                          "and the it-block should supply a done callback.");
+        }
+        var result;
+        try {
+            result = cb();
+        } finally {
+            that._isAsync = false;
+        }
+        if (!result || typeof result.then !== 'function') {
+            asyncMisusage("expect.async requires the block to return a promise or throw an exception.");
+        }
+        result.then(function () {
+            that._isAsync = false;
+            done();
+        }, function (err) {
+            that._isAsync = false;
+            done(err);
+        });
+    };
+};
+
+Unexpected.prototype.diff = function (a, b, output, depth, seen) {
+    output = output || this.createOutput();
+    var that = this;
+
+    depth = typeof depth === 'number' ? depth : 100;
+    if (depth <= 0) {
+        // detect recursive loops in the structure
+        seen = seen || [];
+        if (seen.indexOf(a) !== -1) {
+            throw new Error('Cannot compare circular structures');
+        }
+        seen.push(a);
+    }
+
+    return this.findCommonType(a, b).diff(a, b, output, function (actual, expected) {
+        return that.diff(actual, expected, output.clone(), depth - 1, seen);
+    }, function (v, depth) {
+        return output.clone().appendInspected(v, depth || Infinity);
+    }, function (actual, expected) {
+        return that.equal(actual, expected);
+    });
+};
+
+Unexpected.prototype.toString = function () {
+    var assertions = this.assertions;
+    var types = {};
+    Object.keys(assertions).forEach(function (typeName) {
+        types[typeName] = {};
+        Object.keys(assertions[typeName]).forEach(function (expandedPattern) {
+            types[typeName][expandedPattern] = true;
+        });
+    }, this);
+
+
+    var pen = magicpen();
+    Object.keys(types).sort().forEach(function (type) {
+        var assertionsForType = Object.keys(types[type]).sort();
+        if (assertionsForType.length > 0) {
+            pen.text(type + ':').nl();
+            pen.indentLines();
+
+            assertionsForType.forEach(function (assertion) {
+                pen.i().text(assertion).nl();
+            });
+
+            pen.outdentLines();
+        }
+    });
+
+    return pen.toString();
+};
+
+Unexpected.prototype.clone = function () {
+    var clonedAssertions = {};
+    Object.keys(this.assertions).forEach(function (typeName) {
+        clonedAssertions[typeName] = extend({}, this.assertions[typeName]);
+    }, this);
+    var unexpected = new Unexpected({
+        assertions: clonedAssertions,
+        types: [].concat(this.types),
+        typeByName: extend({}, this.typeByName),
+        output: this.output.clone(),
+        format: this.outputFormat(),
+        installedPlugins: [].concat(this.installedPlugins)
+    });
+    return makeExpectFunction(unexpected);
+};
+
+Unexpected.prototype.outputFormat = function (format) {
+    if (typeof format === 'undefined') {
+        return this._outputFormat;
+    } else {
+        this._outputFormat = format;
+        return this;
+    }
+};
+
+Unexpected.prototype.createOutput = function (format) {
+    var that = this;
+    var output = this.output.clone(format || 'text');
+    output.addStyle('appendInspected', function (value, depth) {
+        if (value && value.isMagicPen) {
+            this.append(value);
+        } else {
+            this.append(that.inspect(value, depth, this.clone()));
+        }
+    });
+    return output;
+};
+
+Unexpected.create = function () {
+    var unexpected = new Unexpected();
+    return makeExpectFunction(unexpected);
+};
+
+var expandPattern = (function () {
+    function isFlag(token) {
+        return token.slice(0, 1) === '[' && token.slice(-1) === ']';
+    }
+    function isAlternation(token) {
+        return token.slice(0, 1) === '(' && token.slice(-1) === ')';
+    }
+    function removeEmptyStrings(texts) {
+        return texts.filter(function (text) {
+            return text !== '';
+        });
+    }
+    function createPermutations(tokens, index) {
+        if (index === tokens.length) {
+            return [{ text: '', flags: {}, alternations: [] }];
+        }
+
+        var token = tokens[index];
+        var tail = createPermutations(tokens, index + 1);
+        if (isFlag(token)) {
+            var flag = token.slice(1, -1);
+            return tail.map(function (pattern) {
+                var flags = {};
+                flags[flag] = true;
+                return {
+                    text: flag + ' ' + pattern.text,
+                    flags: extend(flags, pattern.flags),
+                    alternations: pattern.alternations
+                };
+            }).concat(tail.map(function (pattern) {
+                var flags = {};
+                flags[flag] = false;
+                return {
+                    text: pattern.text,
+                    flags: extend(flags, pattern.flags),
+                    alternations: pattern.alternations
+                };
+            }));
+        } else if (isAlternation(token)) {
+            return token
+                .substr(1, token.length - 2) // Remove parentheses
+                .split(/\|/)
+                .reduce(function (result, alternation) {
+                    return result.concat(tail.map(function (pattern) {
+                        return {
+                            // Make sure that an empty alternation doesn't produce two spaces:
+                            text: alternation ? alternation + pattern.text : pattern.text.replace(/^ /, ''),
+                            flags: pattern.flags,
+                            alternations: [alternation].concat(pattern.alternations)
+                        };
+                    }));
+                }, []);
+        } else {
+            return tail.map(function (pattern) {
+                return {
+                    text: token + pattern.text,
+                    flags: pattern.flags,
+                    alternations: pattern.alternations
+                };
+            });
+        }
+    }
+    return function (pattern) {
+        pattern = pattern.replace(/(\[[^\]]+\]) ?/g, '$1');
+        var splitRegex = /\[[^\]]+\]|\([^\)]+\)/g;
+        var tokens = [];
+        var m;
+        var lastIndex = 0;
+        while ((m = splitRegex.exec(pattern))) {
+            tokens.push(pattern.slice(lastIndex, m.index));
+            tokens.push(pattern.slice(m.index, splitRegex.lastIndex));
+            lastIndex = splitRegex.lastIndex;
+        }
+        tokens.push(pattern.slice(lastIndex));
+        tokens = removeEmptyStrings(tokens);
+        var permutations = createPermutations(tokens, 0);
+        permutations.forEach(function (permutation) {
+            permutation.text = permutation.text.trim();
+            if (permutation.text === '') {
+                // This can only happen if the pattern only contains flags
+                throw new Error("Assertion patterns must not only contain flags");
+            }
+        });
+        return permutations;
+    };
+}());
+
+
+function ensureValidUseOfParenthesesOrBrackets(pattern) {
+    var counts = {
+        '[': 0,
+        ']': 0,
+        '(': 0,
+        ')': 0
+    };
+    for (var i = 0; i < pattern.length; i += 1) {
+        var c = pattern.charAt(i);
+        if (c in counts) {
+            counts[c] += 1;
+        }
+        if (c === ']' && counts['['] >= counts[']']) {
+            if (counts['['] === counts[']'] + 1) {
+                throw new Error("Assertion patterns must not contain flags with brackets: '" + pattern + "'");
+            }
+
+            if (counts['('] !== counts[')']) {
+                throw new Error("Assertion patterns must not contain flags with parentheses: '" + pattern + "'");
+            }
+
+            if (pattern.charAt(i - 1) === '[') {
+                throw new Error("Assertion patterns must not contain empty flags: '" + pattern + "'");
+            }
+        } else if (c === ')' && counts['('] >= counts[')']) {
+            if (counts['('] === counts[')'] + 1) {
+                throw new Error("Assertion patterns must not contain alternations with parentheses: '" + pattern + "'");
+            }
+
+            if (counts['['] !== counts[']']) {
+                throw new Error("Assertion patterns must not contain alternations with brackets: '" + pattern + "'");
+            }
+        }
+    }
+
+    if (counts['['] !== counts[']']) {
+        throw new Error("Assertion patterns must not contain unbalanced brackets: '" + pattern + "'");
+    }
+
+    if (counts['('] !== counts[')']) {
+        throw new Error("Assertion patterns must not contain unbalanced parentheses: '" + pattern + "'");
+    }
+}
+
+function ensureValidPattern(pattern) {
+    if (typeof pattern !== 'string' || pattern === '') {
+        throw new Error("Assertion patterns must be a non-empty string");
+    }
+    if (/^\(?<[a-z.-]+>/.test(pattern)) {
+        throw new Error("Assertion patterns cannot use type signature syntax (reserved for future expansion), ^\\(?<[a-z.-]+>");
+    }
+
+    if (pattern.match(/^\s|\s$/)) {
+        throw new Error("Assertion patterns can't start or end with whitespace");
+    }
+
+    ensureValidUseOfParenthesesOrBrackets(pattern);
+}
+
+module.exports = Unexpected;
+
+},{}],3:[function(require,module,exports){
+var utils = require(13);
+
+var errorMethodBlacklist = ['message', 'line', 'sourceId', 'sourceURL', 'stack', 'stackArray'].reduce(function (result, prop) {
+    result[prop] = true;
+    return result;
+}, {});
+
+function UnexpectedError(expect, assertion, parent) {
+    this.errorMode = (assertion && assertion.errorMode) || 'default';
+    var base = Error.call(this, '');
+
+    if (Error.captureStackTrace) {
+        Error.captureStackTrace(this, UnexpectedError);
+    } else {
+        // Throw the error to make sure it has its stack serialized:
+        try { throw base; } catch (err) {}
+        this.stack = base.stack;
+    }
+
+    this.expect = expect;
+    this.assertion = assertion || null;
+    this.parent = parent || null;
+    this.name = 'UnexpectedError';
+}
+
+UnexpectedError.prototype = Object.create(Error.prototype);
+
+var missingOutputMessage = 'You must either provide a format or a magicpen instance';
+UnexpectedError.prototype.outputFromOptions = function (options) {
+    if (!options) {
+        throw new Error(missingOutputMessage);
+    }
+
+    if (typeof options === 'string') {
+        return this.expect.createOutput(options);
+    }
+
+    if (options.isMagicPen) {
+        return options.clone();
+    }
+
+    if (options.output) {
+        return options.output.clone();
+    }
+
+    if (options.format) {
+        return this.expect.createOutput(options.format);
+    }
+
+    throw new Error(missingOutputMessage);
+};
+
+
+UnexpectedError.prototype._isUnexpected = true;
+UnexpectedError.prototype.isUnexpected = true;
+UnexpectedError.prototype.buildDiff = function (options) {
+    var output = this.outputFromOptions(options);
+    var expect = this.expect;
+    return this.createDiff && this.createDiff(output, function (actual, expected) {
+        return expect.diff(actual, expected, output.clone());
+    }, function (v, depth) {
+        return output.clone().appendInspected(v, depth || Infinity);
+    }, function (actual, expected) {
+        return expect.equal(actual, expected);
+    });
+};
+
+UnexpectedError.prototype.getDefaultErrorMessage = function (options) {
+    var output = this.outputFromOptions(options);
+    if (this.assertion) {
+        output.append(this.assertion.standardErrorMessage(output.clone(), options));
+    } else if (typeof this.output === 'function') {
+        this.output.call(output, output);
+    }
+
+    var errorWithDiff = this;
+    while (!errorWithDiff.createDiff && errorWithDiff.parent) {
+        errorWithDiff = errorWithDiff.parent;
+    }
+
+    if (errorWithDiff && errorWithDiff.createDiff) {
+        var comparison = errorWithDiff.buildDiff(options);
+        if (comparison) {
+            output.nl(2).append(comparison.diff);
+        }
+    }
+
+    return output;
+};
+
+UnexpectedError.prototype.getNestedErrorMessage = function (options) {
+    var output = this.outputFromOptions(options);
+    if (this.assertion) {
+        output.append(this.assertion.standardErrorMessage(output.clone(), options));
+    } else if (typeof this.output === 'function') {
+        this.output.call(output, output);
+    }
+
+    var parent = this.parent;
+    while (parent.getErrorMode() === 'bubble') {
+        parent = parent.parent;
+    }
+
+    if (typeof options === 'string') {
+        options = { format: options };
+    } else if (options && options.isMagicPen) {
+        options = { output: options };
+    }
+
+    output.nl()
+        .indentLines()
+        .i().block(parent.getErrorMessage(utils.extend({}, options || {}, {
+            compact: this.assertion && parent.assertion &&
+                this.assertion.subject === parent.assertion.subject
+        })));
+    return output;
+};
+
+UnexpectedError.prototype.getDiffMethod = function () {
+    var errorWithDiff = this;
+    while (!errorWithDiff.createDiff && errorWithDiff.parent) {
+        errorWithDiff = errorWithDiff.parent;
+    }
+
+    return errorWithDiff && errorWithDiff.createDiff || null;
+};
+
+UnexpectedError.prototype.getDiff = function (options) {
+    var errorWithDiff = this;
+    while (!errorWithDiff.createDiff && errorWithDiff.parent) {
+        errorWithDiff = errorWithDiff.parent;
+    }
+
+    if (errorWithDiff) {
+        var diffResult = errorWithDiff.buildDiff(options);
+        if (diffResult && diffResult.diff) {
+            return diffResult;
+        } else {
+            return null;
+        }
+    } else {
+        return null;
+    }
+};
+
+UnexpectedError.prototype.getDiffMessage = function (options) {
+    var output = this.outputFromOptions(options);
+    var comparison = this.getDiff(options);
+    if (comparison) {
+        output.append(comparison.diff);
+    } else if (this.assertion) {
+        output.append(this.assertion.standardErrorMessage(output.clone(), options));
+    } else if (typeof this.output === 'function') {
+        this.output.call(output, output);
+    }
+    return output;
+};
+
+UnexpectedError.prototype.getErrorMode = function () {
+    if (!this.parent) {
+        switch (this.errorMode) {
+        case 'default':
+        case 'bubbleThrough':
+            return this.errorMode;
+        default:
+            return 'default';
+        }
+    } else {
+        return this.errorMode;
+    }
+};
+
+
+UnexpectedError.prototype.getErrorMessage = function (options) {
+    // Search for any parent error that has an error mode of 'bubbleThrough' through on the
+    // error these should be bubbled to the top
+    var errorWithBubbleThrough = this.parent;
+    while (errorWithBubbleThrough && errorWithBubbleThrough.getErrorMode() !== 'bubbleThrough') {
+        errorWithBubbleThrough = errorWithBubbleThrough.parent;
+    }
+    if (errorWithBubbleThrough) {
+        return errorWithBubbleThrough.getErrorMessage(options);
+    }
+
+    var errorMode = this.getErrorMode();
+    switch (errorMode) {
+    case 'nested': return this.getNestedErrorMessage(options);
+    case 'default': return this.getDefaultErrorMessage(options);
+    case 'bubbleThrough': return this.getDefaultErrorMessage(options);
+    case 'bubble': return this.parent.getErrorMessage(options);
+    case 'diff': return this.getDiffMessage(options);
+    default: throw new Error("Unknown error mode: '" + errorMode + "'");
+    }
+};
+
+UnexpectedError.prototype.serializeMessage = function (outputFormat) {
+    if (!this._hasSerializedErrorMessage) {
+        if (outputFormat === 'html') {
+            outputFormat = 'text';
+            if (!('htmlMessage' in this)) {
+                this.htmlMessage = this.getErrorMessage({format: 'html'}).toString();
+            }
+        }
+        this.message = '\n' + this.getErrorMessage({format: outputFormat}).toString();
+
+        this._hasSerializedErrorMessage = true;
+    }
+};
+
+UnexpectedError.prototype.clone = function () {
+    var that = this;
+    var newError = new UnexpectedError(this.expect);
+    Object.keys(that).forEach(function (key) {
+        if (!errorMethodBlacklist[key]) {
+            newError[key] = that[key];
+        }
+    });
+    return newError;
+};
+
+UnexpectedError.prototype.getLabel = function () {
+    var currentError = this;
+    while (currentError && !currentError.label) {
+        currentError = currentError.parent;
+    }
+    return (currentError && currentError.label) || null;
+};
+
+UnexpectedError.prototype.getParents = function () {
+    var result = [];
+    var parent = this.parent;
+    while (parent) {
+        result.push(parent);
+        parent = parent.parent;
+    }
+    return result;
+};
+
+UnexpectedError.prototype.getAllErrors = function () {
+    var result = this.getParents();
+    result.unshift(this);
+    return result;
+};
+
+if (Object.__defineGetter__) {
+    Object.defineProperty(UnexpectedError.prototype, 'htmlMessage', {
+        enumerable: true,
+        get: function () {
+            return this.getErrorMessage({ format: 'html' }).toString();
+        }
+    });
+}
+
+module.exports = UnexpectedError;
+
+},{}],4:[function(require,module,exports){
+(function (Buffer){
+/*global setTimeout*/
+var utils = require(13);
+var objectIs = utils.objectIs;
+var isRegExp = utils.isRegExp;
+var isArray = utils.isArray;
+var extend = utils.extend;
+
+module.exports = function (expect) {
+    expect.addAssertion('[not] to be (ok|truthy)', function (expect, subject) {
+        var not = !!this.flags.not;
+        var condition = !!subject;
+        if (condition === not) {
+            expect.fail();
+        }
+    });
+
+    expect.addAssertion('[not] to be', function (expect, subject, value) {
+        expect(objectIs(subject, value), '[not] to be truthy');
+    });
+
+    expect.addAssertion('string', '[not] to be', function (expect, subject, value) {
+        expect(subject, '[not] to equal', value);
+    });
+
+    expect.addAssertion('boolean', '[not] to be true', function (expect, subject) {
+        expect(subject, '[not] to be', true);
+    });
+
+    expect.addAssertion('boolean', '[not] to be false', function (expect, subject) {
+        expect(subject, '[not] to be', false);
+    });
+
+    expect.addAssertion('[not] to be falsy', function (expect, subject) {
+        expect(subject, '[!not] to be truthy');
+    });
+
+    expect.addAssertion('[not] to be null', function (expect, subject) {
+        expect(subject, '[not] to be', null);
+    });
+
+    expect.addAssertion('[not] to be undefined', function (expect, subject) {
+        expect(typeof subject === 'undefined', '[not] to be truthy');
+    });
+
+    expect.addAssertion('to be defined', function (expect, subject) {
+        expect(subject, 'not to be undefined');
+    });
+
+    expect.addAssertion(['number', 'NaN'], '[not] to be NaN', function (expect, subject) {
+        expect(isNaN(subject), '[not] to be truthy');
+    });
+
+    expect.addAssertion('number', '[not] to be close to', function (expect, subject, value, epsilon) {
+        this.errorMode = 'bubble';
+        if (typeof epsilon !== 'number') {
+            epsilon = 1e-9;
+        }
+
+        var testDescription = this.testDescription;
+        expect.withError(function () {
+            expect(Math.abs(subject - value), '[not] to be less than or equal to', epsilon);
+        }, function (e) {
+            expect.fail(function (output) {
+                output.error('expected ')
+                    .appendInspected(subject).sp()
+                    .error(testDescription).sp()
+                    .appendInspected(value).sp()
+                    .text('(epsilon: ')
+                    .jsNumber(epsilon.toExponential())
+                    .text(')');
+            });
+        });
+    });
+
+    expect.addAssertion('[not] to be (a|an)', function (expect, subject, type) {
+        if ('string' === typeof type) {
+            var subjectType = expect.findTypeOf(subject);
+            type = /^reg(?:exp?|ular expression)$/.test(type) ? 'regexp' : type;
+            this.argsOutput[0] = function (output) {
+                output.jsString(type);
+            };
+            expect(subjectType.is(type), '[not] to be truthy');
+        } else if ('function' === typeof type) {
+            var functionName = utils.getFunctionName(type);
+            if (functionName) {
+                this.argsOutput[0] = function (output) {
+                    output.text(functionName);
+                };
+            }
+            expect(subject instanceof type, '[not] to be truthy');
+        } else if ('object' === typeof type && type) {
+            if (typeof type.identify !== 'function' || typeof type.name !== 'string') {
+                throw new Error("The '" + this.testDescription + "' assertion requires either a string (type name), a type object, or function argument");
+            }
+            this.argsOutput[0] = function (output) {
+                output.text(type.name);
+            };
+            expect(type.identify(subject), '[not] to be true');
+        } else {
+            throw new Error("The '" + this.testDescription + "' assertion requires either a string (type name), a type object, or function argument");
+        }
+    });
+
+    // Alias for common '[not] to be (a|an)' assertions
+    expect.addAssertion('[not] to be an (object|array)', function (expect, subject) {
+        expect(subject, '[not] to be an', this.alternations[0]);
+    });
+
+    expect.addAssertion('[not] to be a (boolean|number|string|function|regexp|regex|regular expression)', function (expect, subject) {
+        expect(subject, '[not] to be a', this.alternations[0]);
+    });
+
+    expect.addAssertion('string', 'to be (the empty|an empty|a non-empty) string', function (expect, subject) {
+        expect(subject, this.alternations[0] === 'a non-empty' ? 'not to be empty' : 'to be empty');
+    });
+
+    expect.addAssertion('array-like', 'to be (the empty|an empty|a non-empty) array', function (expect, subject) {
+        expect(subject, this.alternations[0] === 'a non-empty' ? 'not to be empty' : 'to be empty');
+    });
+
+    expect.addAssertion('string', '[not] to match', function (expect, subject, regexp) {
+        var flags = this.flags;
+        subject = String(subject);
+        return expect.withError(function () {
+            var captures = String(subject).match(regexp);
+            expect(captures, '[not] to be truthy');
+            return captures;
+        }, function (e) {
+            expect.fail({
+                label: 'should match',
+                diff: flags.not && function (output) {
+                    var lastIndex = 0;
+                    function flushUntilIndex(i) {
+                        if (i > lastIndex) {
+                            output.text(subject.substring(lastIndex, i));
+                            lastIndex = i;
+                        }
+                    }
+                    subject.replace(new RegExp(regexp.source, 'g'), function ($0, index) {
+                        flushUntilIndex(index);
+                        lastIndex += $0.length;
+                        $0.split(/(\n)/).forEach(function (fragment) {
+                            if (fragment === '\n') {
+                                output.nl();
+                            } else {
+                                output.removedHighlight(fragment);
+                            }
+                        });
+                    });
+                    flushUntilIndex(subject.length);
+                    return {diff: output};
+                }
+            });
+        });
+    });
+
+    expect.addAssertion('object', '[not] to have [own] property', function (expect, subject, key, value) {
+        if (arguments.length === 4) {
+            if (this.flags.not) {
+                throw new Error("The '" + this.testDescription + "' assertion does not work with a value argument");
+            }
+
+            expect(subject, 'to have [own] property', key);
+            expect(subject[key], '[not] to equal', value);
+        } else {
+            expect(this.flags.own ?
+                   subject && subject.hasOwnProperty(key) :
+                   subject && subject[key] !== undefined,
+                   '[not] to be truthy');
+        }
+    });
+
+    expect.addAssertion('object', '[not] to have [own] properties', function (expect, subject, properties) {
+        if (properties && isArray(properties)) {
+            properties.forEach(function (property) {
+                expect(subject, '[not] to have [own] property', property);
+            });
+        } else if (properties && typeof properties === 'object') {
+            var flags = this.flags;
+
+            if (flags.not) {
+                throw new Error("Assertion '" + this.testDescription + "' only supports " +
+                                "input in the form of an Array.");
+            }
+
+            expect.withError(function () {
+                Object.keys(properties).forEach(function (property) {
+                    var value = properties[property];
+                    if (typeof value === 'undefined') {
+                        expect(subject, 'not to have [own] property', property);
+                    } else {
+                        expect(subject, 'to have [own] property', property, value);
+                    }
+                });
+            }, function (e) {
+                expect.fail({
+                    diff: function (output, diff) {
+                        var expected = extend({}, properties);
+                        var actual = {};
+                        var propertyNames = expect.findTypeOf(subject).getKeys(subject);
+                        // Might put duplicates into propertyNames, but that does not matter:
+                        for (var propertyName in subject) {
+                            if (!subject.hasOwnProperty(propertyName)) {
+                                propertyNames.push(propertyName);
+                            }
+                        }
+                        propertyNames.forEach(function (propertyName) {
+                            if ((!flags.own || subject.hasOwnProperty(propertyName)) && !(propertyName in properties)) {
+                                expected[propertyName] = subject[propertyName];
+                            }
+                            if ((!flags.own || subject.hasOwnProperty(propertyName)) && !(propertyName in actual)) {
+                                actual[propertyName] = subject[propertyName];
+                            }
+                        });
+                        var result = diff(actual, expected);
+                        result.diff = utils.wrapConstructorNameAroundOutput(result.diff, subject);
+                        return result;
+                    }
+                });
+            });
+        } else {
+            throw new Error("Assertion '" + this.testDescription + "' only supports " +
+                            "input in the form of an Array or an Object.");
+        }
+    });
+
+    expect.addAssertion(['string', 'array-like'], '[not] to have length', function (expect, subject, length) {
+        if (!this.flags.not) {
+            this.errorMode = 'nested';
+        }
+
+        expect(subject.length, '[not] to be', length);
+    });
+
+    expect.addAssertion(['string', 'array-like'], '[not] to be empty', function (expect, subject) {
+        expect(subject, '[not] to have length', 0);
+    });
+
+    expect.addAssertion(['string', 'array-like'], 'to be non-empty', function (expect, subject) {
+        expect(subject, 'not to be empty');
+    });
+
+    expect.addAssertion('object', ['to [not] [only] have (key|keys)', '[not] to have (key|keys)'], function (expect, subject, keys) {
+        keys = isArray(keys) ?
+            keys :
+            Array.prototype.slice.call(arguments, 2);
+
+        var keysInSubject = {};
+        var subjectKeys = expect.findTypeOf(subject).getKeys(subject);
+        subjectKeys.forEach(function (key) {
+            keysInSubject[key] = true;
+        });
+
+        if (this.flags.not && keys.length === 0) {
+            return;
+        }
+
+        var hasKeys = subject && keys.every(function (key) {
+            return keysInSubject[key];
+        });
+
+        if (this.flags.only) {
+            expect(hasKeys, 'to be truthy');
+            expect(subjectKeys.length === keys.length, '[not] to be truthy');
+        } else {
+            expect(hasKeys, '[not] to be truthy');
+        }
+    });
+
+    expect.addAssertion('string', '[not] to contain', function (expect, subject) {
+        var flags = this.flags;
+        var args = Array.prototype.slice.call(arguments, 2);
+        expect.withError(function () {
+            args.forEach(function (arg) {
+                expect(subject.indexOf(arg) !== -1, '[not] to be truthy');
+            });
+        }, function (e) {
+            expect.fail({
+                diff: function (output) {
+                    var lastIndex = 0;
+                    function flushUntilIndex(i) {
+                        if (i > lastIndex) {
+                            output.text(subject.substring(lastIndex, i));
+                            lastIndex = i;
+                        }
+                    }
+                    if (flags.not) {
+                        subject.replace(new RegExp(args.map(function (arg) {
+                            return utils.escapeRegExpMetaChars(String(arg));
+                        }).join('|'), 'g'), function ($0, index) {
+                            flushUntilIndex(index);
+                            lastIndex += $0.length;
+                            $0.split(/(\n)/).forEach(function (fragment) {
+                                if (fragment === '\n') {
+                                    output.nl();
+                                } else {
+                                    output.removedHighlight(fragment);
+                                }
+                            });
+                        });
+                        flushUntilIndex(subject.length);
+                    } else {
+                        var ranges = [];
+                        args.forEach(function (arg) {
+                            var needle = String(arg);
+                            var partial = false;
+                            while (needle.length > 1) {
+                                var found = false;
+                                lastIndex = -1;
+                                var index;
+                                do {
+                                    index = subject.indexOf(needle, lastIndex + 1);
+                                    if (index !== -1) {
+                                        found = true;
+                                        ranges.push({
+                                            startIndex: index,
+                                            endIndex: index + needle.length,
+                                            partial: partial
+                                        });
+                                    }
+                                    lastIndex = index;
+                                } while (lastIndex !== -1);
+                                if (found) {
+                                    break;
+                                }
+                                needle = arg.substr(0, needle.length - 1);
+                                partial = true;
+                            }
+                        });
+                        lastIndex = 0;
+                        ranges.sort(function (a, b) {
+                            return a.startIndex - b.startIndex;
+                        }).forEach(function (range) {
+                            flushUntilIndex(range.startIndex);
+                            var firstUncoveredIndex = Math.max(range.startIndex, lastIndex);
+                            if (range.endIndex > firstUncoveredIndex) {
+                                subject.substring(firstUncoveredIndex, range.endIndex).split(/(\n)/).forEach(function (fragment) {
+                                    if (fragment === '\n') {
+                                        output.nl();
+                                    } else {
+                                        if (range.partial) {
+                                            output.partialMatch(fragment);
+                                        } else {
+                                            output.match(fragment);
+                                        }
+                                    }
+                                });
+                                lastIndex = range.endIndex;
+                            }
+                        });
+                        flushUntilIndex(subject.length);
+                    }
+                    return {diff: output};
+                }
+            });
+        });
+    });
+
+    expect.addAssertion('array-like', '[not] to contain', function (expect, subject) {
+        var flags = this.flags;
+        var args = Array.prototype.slice.call(arguments, 2);
+        expect.withError(function () {
+            args.forEach(function (arg) {
+                expect(subject && Array.prototype.some.call(subject, function (item) {
+                    return expect.equal(item, arg);
+                }), '[not] to be truthy');
+            });
+        }, function (e) {
+            expect.fail({
+                diff: flags.not && function (output, diff, inspect, equal) {
+                    return diff(subject, Array.prototype.filter.call(subject, function (item) {
+                        return !args.some(function (arg) {
+                            return equal(item, arg);
+                        });
+                    }));
+                }
+            });
+        });
+    });
+
+    expect.addAssertion('number', '[not] to be finite', function (expect, subject) {
+        expect(isFinite(subject), '[not] to be truthy');
+    });
+
+    expect.addAssertion('number', '[not] to be infinite', function (expect, subject) {
+        expect(!isNaN(subject) && !isFinite(subject), '[not] to be truthy');
+    });
+
+    expect.addAssertion(['number', 'string'], '[not] to be within', function (expect, subject, start, finish) {
+        this.argsOutput = function (output) {
+            output.appendInspected(start).text('..').appendInspected(finish);
+        };
+        expect(subject >= start && subject <= finish, '[not] to be truthy');
+    });
+
+    expect.addAssertion(['number', 'string'], ['<', '[not] to be (<|less than|below)'], function (expect, subject, value) {
+        expect(subject < value, '[not] to be truthy');
+    });
+
+    expect.addAssertion(['number', 'string'], ['<=', '[not] to be (<=|less than or equal to)'], function (expect, subject, value) {
+        expect(subject <= value, '[not] to be truthy');
+    });
+
+    expect.addAssertion(['number', 'string'], ['>', '[not] to be (>|greater than|above)'], function (expect, subject, value) {
+        expect(subject > value, '[not] to be truthy');
+    });
+
+    expect.addAssertion(['number', 'string'], ['>=', '[not] to be (>=|greater than or equal to)'], function (expect, subject, value) {
+        expect(subject >= value, '[not] to be truthy');
+    });
+
+    expect.addAssertion('number', '[not] to be positive', function (expect, subject) {
+        expect(subject, '[not] to be >', 0);
+    });
+
+    expect.addAssertion('number', '[not] to be negative', function (expect, subject) {
+        expect(subject, '[not] to be <', 0);
+    });
+
+    expect.addAssertion('[not] to equal', function (expect, subject, value) {
+        var flags = this.flags;
+        expect.withError(function () {
+            expect(expect.equal(value, subject), '[not] to be truthy');
+        }, function (e) {
+            expect.fail({
+                label: 'should equal',
+                diff: !flags.not && function (output, diff) {
+                    return diff(subject, value);
+                }
+            });
+        });
+    });
+
+    expect.addAssertion('function', '[not] to error', function (expect, subject, arg) {
+        var hasArg = arguments.length > 2;
+        var that = this;
+        var threw = false;
+
+        if (this.flags.not && hasArg) {
+            throw new Error("The 'not to error' assertion does not support arguments");
+        }
+
+        return expect.promise(function () {
+            try {
+                return subject();
+            } catch (e) {
+                threw = true;
+                throw e;
+            }
+        }).then(function () {
+            if (!that.flags.not) {
+                return expect.promise(function () {
+                    expect.fail(function (output) {
+                        output.text('expected').sp();
+                        output.appendInspect(subject).sp().text('to error');
+                    });
+                });
+            }
+        }, function (error) {
+            if (that.flags.not) {
+                that.errorMode = 'nested';
+                expect.fail(function (output) {
+                    output.error(threw ? 'threw' : 'returned promise rejected with').error(': ')
+                        .appendErrorMessage(error);
+                });
+            } else if (hasArg) {
+                that.errorMode = 'nested';
+                if (error.isUnexpected && (typeof arg === 'string' || isRegExp(arg))) {
+                    return expect(error, 'to have text message', arg);
+                } else {
+                    return expect(error, 'to satisfy', arg);
+                }
+            }
+        });
+    });
+
+    expect.addAssertion('function', '[not] to (throw|throw error|throw exception)', function (expect, subject, arg) {
+        var thrown = false;
+        var error;
+        var hasArg = arguments.length > 2;
+
+        if (this.flags.not && hasArg) {
+            throw new Error("The 'not to throw' assertion does not support arguments");
+        }
+
+        try {
+            subject();
+        } catch (e) {
+            error = e;
+            thrown = true;
+        }
+
+        var isUnexpected = error && error._isUnexpected;
+        if (hasArg) {
+            // in the presence of a matcher an error must have been thrown.
+            expect(thrown, 'to be truthy');
+
+            this.errorMode = 'nested';
+            if (isUnexpected && (typeof arg === 'string' || isRegExp(arg))) {
+                return expect(error.getErrorMessage('text').toString(), 'to satisfy', arg);
+            } else {
+                return expect(error, 'to satisfy', arg);
+            }
+        } else if (this.flags.not && thrown) {
+            this.errorMode = 'nested';
+            expect.fail(function (output) {
+                output.error('threw: ').appendErrorMessage(error);
+            });
+        } else {
+            expect(thrown, '[not] to be truthy');
+        }
+    });
+
+    expect.addAssertion('function', 'to have arity', function (expect, subject, value) {
+        expect(subject.length, 'to equal', value);
+    });
+
+    expect.addAssertion('object', [
+        'to have values satisfying',
+        'to be (a map|a hash|an object) whose values satisfy'
+    ], function (expect, subject) {
+        var that = this;
+        var extraArgs = Array.prototype.slice.call(arguments, 2);
+        if (extraArgs.length === 0) {
+            throw new Error('Assertion "' + this.testDescription + '" expects a third argument');
+        }
+        this.errorMode = 'nested';
+        expect(subject, 'not to equal', {});
+        this.errorMode = 'bubble';
+
+        var subjectType = expect.findTypeOf(subject);
+        var keys = subjectType.getKeys(subject);
+        var expected = Array.isArray(subject) ? [] : {};
+        if (typeof extraArgs[0] === 'function') {
+            keys.forEach(function (key, index) {
+                expected[key] = function (s) {
+                    return extraArgs[0](s, index);
+                };
+            });
+        } else {
+            keys.forEach(function (key, index) {
+                expected[key] = function (s) {
+                    return expect.apply(expect, [s, 'to satisfy assertion'].concat(extraArgs));
+                };
+            });
+        }
+
+        return expect.withError(function () {
+            return expect(subject, 'to satisfy', expected);
+        }, function (err) {
+            expect.fail({
+                message: function (output) {
+                    output.append(that.standardErrorMessage(output.clone(), { compact: true }));
+                },
+                diff: function (output) {
+                    var diff = err.getDiff({ output: output });
+                    diff.inline = true;
+                    return diff;
+                }
+            });
+        });
+    });
+
+    expect.addAssertion('array-like', [
+        'to have items satisfying',
+        'to be an array whose items satisfy'
+    ], function (expect, subject) { // ...
+        var extraArgs = Array.prototype.slice.call(arguments, 2);
+        if (extraArgs.length === 0) {
+            throw new Error('Assertion "' + this.testDescription + '" expects a third argument');
+        }
+        this.errorMode = 'nested';
+        expect(subject, 'to be non-empty');
+        this.errorMode = 'bubble';
+        return expect.apply(expect, [subject, 'to have values satisfying'].concat(extraArgs));
+    });
+
+    expect.addAssertion('object', [
+        'to have keys satisfying',
+        'to be (a map|a hash|an object) whose (keys|properties) satisfy'
+    ], function (expect, subject) {
+        var that = this;
+        var extraArgs = Array.prototype.slice.call(arguments, 2);
+        if (extraArgs.length === 0) {
+            throw new Error('Assertion "' + this.testDescription + '" expects a third argument');
+        }
+        this.errorMode = 'nested';
+        expect(subject, 'to be an object');
+        expect(subject, 'not to equal', {});
+        this.errorMode = 'bubble';
+
+        var subjectType = expect.findTypeOf(subject);
+        var keys = subjectType.getKeys(subject);
+        var expected = Array.isArray(subject) ? [] : {};
+        if (typeof extraArgs[0] === 'function') {
+            keys.forEach(function (key, index) {
+                expected[key] = function () {
+                    return extraArgs[0](key, subject[key]);
+                };
+            });
+        } else {
+            keys.forEach(function (key, index) {
+                expected[key] = function () {
+                    return expect.apply(expect, [key, 'to satisfy assertion'].concat(extraArgs));
+                };
+            });
+        }
+
+        return expect.withError(function () {
+            return expect(subject, 'to satisfy', expected);
+        }, function (err) {
+            expect.fail({
+                message: function (output) {
+                    output.append(that.standardErrorMessage(output.clone(), { compact: true }));
+                },
+                diff: function (output) {
+                    var diff = err.getDiff({ output: output });
+                    diff.inline = true;
+                    return diff;
+                }
+            });
+        });
+    });
+
+    expect.addAssertion('object', 'to be canonical', function (expect, subject) {
+        var stack = [];
+
+        (function traverse(obj) {
+            var i;
+            for (i = 0 ; i < stack.length ; i += 1) {
+                if (stack[i] === obj) {
+                    return;
+                }
+            }
+            if (obj && typeof obj === 'object') {
+                var keys = Object.keys(obj);
+                for (i = 0 ; i < keys.length - 1 ; i += 1) {
+                    expect(keys[i], 'to be less than', keys[i + 1]);
+                }
+                stack.push(obj);
+                keys.forEach(function (key) {
+                    traverse(obj[key]);
+                });
+                stack.pop();
+            }
+        }(subject));
+    });
+
+    expect.addAssertion('Error', 'to have (ansi|html|text|) message', function (expect, subject, value) {
+        this.errorMode = 'nested';
+        if (subject.isUnexpected) {
+            return expect(subject.getErrorMessage({ format: this.alternations[0] || 'text' }).toString(), 'to satisfy', value);
+        } else {
+            if (this.alternations[0] !== '' && this.alternations[0] !== 'text') {
+                expect.fail('Cannot get the html representation of non-Unexpected error');
+            } else {
+                return expect(subject.message, 'to satisfy', value);
+            }
+        }
+    });
+
+    expect.addAssertion('Error', 'to [exhaustively] satisfy', function (expect, subject, value) {
+        var valueType = expect.findTypeOf(value);
+        if (valueType.is('Error')) {
+            expect(subject.constructor, 'to be', value.constructor);
+            expect(subject, 'to have properties', valueType.unwrap(value));
+        } else if (typeof value === 'function') {
+            return expect.promise(function () {
+                return value(subject);
+            });
+        } else if (valueType.is('object')) {
+            var subjectType = expect.findTypeOf(subject);
+            var subjectKeys = subjectType.getKeys(subject);
+            var valueKeys = valueType.getKeys(value);
+            var convertedSubject = {};
+            subjectKeys.concat(valueKeys).forEach(function (key) {
+                convertedSubject[key] = subject[key];
+            });
+            return expect(convertedSubject, 'to [exhaustively] satisfy', value);
+        } else {
+            return expect(subject.message, 'to [exhaustively] satisfy', value);
+        }
+    });
+
+    expect.addAssertion('binaryArray', 'to [exhaustively] satisfy', function (expect, subject, value) {
+        var valueType = expect.findTypeOf(value);
+        if (valueType.is('expect.it')) {
+            return expect.withError(function () {
+                return value(subject);
+            }, function (e) {
+                expect.fail({
+                    diff: function (output, diff, inspect, equal) {
+                        return {
+                            diff: output.appendErrorMessage(e),
+                            inline: false
+                        };
+                    }
+                });
+            });
+        } else if (valueType.is('function')) {
+            return expect.promise(function () {
+                return value(subject);
+            });
+        } else {
+            expect(subject, 'to equal', value);
+        }
+    });
+
+    if (typeof Buffer !== 'undefined') {
+        expect.addAssertion('Buffer', 'when decoded as', function (expect, subject, value) {
+            return this.shift(subject.toString(value), 1);
+        });
+    }
+
+    expect.addAssertion('[not] to [exhaustively] satisfy [assertion]', function (expect, subject, value) {
+        if (this.flags.not) {
+            return expect.promise(function (resolve, reject) {
+                return expect.promise(function () {
+                    return expect(subject, 'to [exhaustively] satisfy [assertion]', value);
+                }).then(function () {
+                    try {
+                        expect.fail();
+                    } catch (e) {
+                        reject(e);
+                    }
+                }).caught(function (e) {
+                    if (!e || !e._isUnexpected) {
+                        reject(e);
+                    } else {
+                        resolve();
+                    }
+                });
+            });
+        }
+
+        if (this.flags.assertion) {
+            this.errorMode = 'bubble'; // to satisfy assertion 'to be a number' => to be a number
+            if (typeof value === 'string') {
+                return expect.apply(expect, Array.prototype.slice.call(arguments, 1));
+            } else {
+                return expect.apply(expect, [subject, this.flags.exhaustively ? 'to exhaustively satisfy' : 'to satisfy'].concat(Array.prototype.slice.call(arguments, 2)));
+            }
+        }
+
+        var valueType = expect.findTypeOf(value);
+        if (valueType.is('expect.it')) {
+            return expect.withError(function () {
+                return value(subject);
+            }, function (e) {
+                expect.fail({
+                    diff: function (output) {
+                        return {
+                            diff: output.appendErrorMessage(e),
+                            inline: false
+                        };
+                    }
+                });
+            });
+        }
+
+        if (valueType.is('function')) {
+            return expect.promise(function () {
+                return value(subject);
+            });
+        }
+
+        if (valueType.is('regexp')) {
+            return expect(subject, 'to match', value);
+        }
+
+        var subjectType = expect.findTypeOf(subject),
+            commonType = expect.findCommonType(subject, value),
+            bothAreArrayLike = commonType.is('array-like');
+        if (commonType.is('array-like') || commonType.is('object')) {
+            expect(subject, 'to be an object');
+            var promiseByKey = {};
+            var keys = valueType.getKeys(value);
+            keys.forEach(function (key, index) {
+                promiseByKey[key] = expect.promise(function () {
+                    var valueKeyType = expect.findTypeOf(value[key]);
+                    if (valueKeyType.is('function')) {
+                        return value[key](subject[key]);
+                    } else {
+                        return expect(subject[key], 'to [exhaustively] satisfy', value[key]);
+                    }
+                });
+            });
+
+            var flags = this.flags;
+
+            return expect.promise.all([
+                expect.promise(function () {
+                    if (commonType.is('array-like') || flags.exhaustively) {
+                        expect(subject, 'to only have keys', keys);
+                    }
+                }),
+                expect.promise.all(promiseByKey)
+            ]).caught(function () {
+                return expect.promise.settle(promiseByKey).then(function () {
+                    expect.fail({
+                        diff: function (output, diff, inspect, equal) {
+                            var result = {
+                                diff: output,
+                                inline: true
+                            };
+
+                            var valueType = expect.findTypeOf(value);
+                            var keyIndex = {};
+                            var subjectIsArrayLike = subjectType.is('array-like');
+                            subjectType.getKeys(subject).concat(valueType.getKeys(value)).forEach(function (key) {
+                                if (!(key in keyIndex)) {
+                                    keyIndex[key] = key;
+                                }
+                            });
+
+                            var keys = Object.keys(keyIndex);
+
+                            subjectType.prefix(output, subject);
+                            output.nl().indentLines();
+
+                            keys.forEach(function (key, index) {
+                                output.i().block(function () {
+                                    var valueOutput;
+                                    var annotation = output.clone();
+                                    var conflicting;
+
+                                    if (promiseByKey[key] && promiseByKey[key].isRejected()) {
+                                        conflicting = promiseByKey[key].reason();
+                                    }
+                                    var arrayItemOutOfRange = bothAreArrayLike && (index >= subject.length || index >= value.length);
+
+                                    var isInlineDiff = true;
+
+                                    if (!(key in value)) {
+                                        if (commonType.is('array-like') || flags.exhaustively) {
+                                            annotation.error('should be removed');
+                                        } else {
+                                            conflicting = null;
+                                        }
+                                    } else if (conflicting || arrayItemOutOfRange) {
+                                        var keyDiff = conflicting && conflicting.getDiff({ output: output });
+                                        isInlineDiff = !keyDiff || keyDiff.inline ;
+                                        if (keyDiff && keyDiff.diff && keyDiff.inline) {
+                                            valueOutput = keyDiff.diff;
+                                        } else if (typeof value[key] === 'function') {
+                                            isInlineDiff = false;
+                                            annotation.appendErrorMessage(conflicting);
+                                        } else if (!keyDiff || (keyDiff && !keyDiff.inline)) {
+                                            annotation.error((conflicting && conflicting.getLabel()) || 'should satisfy').sp()
+                                                .block(inspect(value[key]));
+
+                                            if (keyDiff) {
+                                                annotation.nl().append(keyDiff.diff);
+                                            }
+                                        } else {
+                                            valueOutput = keyDiff.diff;
+                                        }
+                                    }
+
+                                    var last = index === keys.length - 1;
+                                    if (!valueOutput) {
+                                        if (bothAreArrayLike && key >= subject.length) {
+                                            valueOutput = output.clone();
+                                        } else {
+                                            valueOutput = inspect(subject[key], conflicting ? Infinity : 1);
+                                        }
+                                    }
+
+                                    if (!subjectIsArrayLike) {
+                                        this.key(key).text(':');
+                                    }
+                                    valueOutput.amend('text', last ? '' : ',');
+
+                                    if (!subjectIsArrayLike) {
+                                        if (valueOutput.isBlock() && valueOutput.isMultiline()) {
+                                            this.indentLines();
+                                            this.nl().i();
+                                        } else {
+                                            this.sp();
+                                        }
+                                    }
+
+                                    if (isInlineDiff) {
+                                        this.append(valueOutput);
+                                    } else {
+                                        this.block(valueOutput);
+                                    }
+                                    if (!annotation.isEmpty()) {
+                                        this.sp(valueOutput.isEmpty() ? 0 : 1).annotationBlock(annotation);
+                                    }
+                                }).nl();
+                            });
+
+                            output.outdentLines();
+                            subjectType.suffix(output, subject);
+
+                            return result;
+                        }
+                    });
+                });
+            });
+        } else {
+            this.errorMode = 'bubble';
+            expect(subject, 'to equal', value);
+        }
+    });
+
+    function wrapDiffWithTypePrefixAndSuffix(e, type, subject) {
+        var createDiff = e.getDiffMethod();
+        if (createDiff) {
+            return function (output) { // ...
+                type.prefix.call(type, output, subject);
+                var result = createDiff.apply(this, arguments);
+                type.suffix.call(type, output, subject);
+                return result;
+            };
+        }
+    }
+
+    expect.addAssertion('wrapperObject', 'to [exhaustively] satisfy', function (expect, subject, value) {
+        var valueType = expect.findTypeOf(value);
+        if (valueType.is('wrapperObject')) {
+            var type = expect.findCommonType(subject, value);
+            expect(type.is('wrapperObject'), 'to be truthy');
+            return expect.withError(function () {
+                return expect(type.unwrap(subject), 'to [exhaustively] satisfy', type.unwrap(value));
+            }, function (e) {
+                expect.fail({
+                    label: e.getLabel(),
+                    diff: wrapDiffWithTypePrefixAndSuffix(e, type, subject)
+                });
+            });
+        } else {
+            var subjectType = expect.findTypeOf(subject);
+
+            return expect.withError(function () {
+                return expect(subjectType.unwrap(subject), 'to [exhaustively] satisfy', value);
+            }, function (e) {
+                expect.fail({
+                    label: e.getLabel(),
+                    diff: wrapDiffWithTypePrefixAndSuffix(e, subjectType, subject)
+                });
+            });
+        }
+    });
+
+    expect.addAssertion('function', 'when called with', function (expect, subject, args) { // ...
+        this.errorMode = 'nested';
+        return this.shift(subject.apply(subject, args), 1);
+    });
+
+    function instantiate(Constructor, args) {
+        function ProxyConstructor() {
+            return Constructor.apply(this, args);
+        }
+        ProxyConstructor.prototype = Constructor.prototype;
+        return new ProxyConstructor();
+    }
+
+    expect.addAssertion('array-like', [
+        'when passed as parameters to [async]',
+        'when passed as parameters to [constructor]'
+    ], function (expect, subject, fn) { // ...
+        this.errorMode = 'nested';
+        var that = this,
+            args = subject;
+        if (that.flags.async) {
+            return expect.promise(function (run) {
+                args = [].concat(args);
+                args.push(run(function (err, result) {
+                    expect(err, 'to be falsy');
+                    return that.shift(result, 1);
+                }));
+                fn.apply(null, args);
+            });
+        } else {
+            subject = that.flags.constructor ? instantiate(fn, args) : fn.apply(fn, args);
+            return that.shift(subject, 1);
+        }
+    });
+
+    expect.addAssertion([
+        'when passed as parameter to [async]',
+        'when passed as parameter to [constructor]'
+    ], function (expect, subject, fn) { // ...
+        this.errorMode = 'nested';
+        var that = this,
+            args = [subject];
+        if (that.flags.async) {
+            return expect.promise(function (run) {
+                args = [].concat(args);
+                args.push(run(function (err, result) {
+                    expect(err, 'to be falsy');
+                    return that.shift(result, 1);
+                }));
+                fn.apply(null, args);
+            });
+        } else {
+            subject = that.flags.constructor ? instantiate(fn, args) : fn.apply(fn, args);
+            return that.shift(subject, 1);
+        }
+    });
+
+    expect.addAssertion('Promise', 'to be rejected [with]', function (expect, subject, value) {
+        this.errorMode = 'nested';
+        var flags = this.flags;
+        return subject.then(function (obj) {
+            expect.fail(function (output) {
+                output.appendInspected(subject).sp().text('unexpectedly fulfilled');
+                if (typeof obj !== 'undefined') {
+                    output.sp().text('with').sp().appendInspected(obj);
+                }
+            });
+        }, function (err) {
+            if (flags['with'] || typeof value !== 'undefined') {
+                if (err && err._isUnexpected && (typeof value === 'string' || isRegExp(value))) {
+                    return expect(err, 'to have text message', value);
+                } else {
+                    return expect(err, 'to satisfy', value);
+                }
+            }
+        });
+    });
+
+    expect.addAssertion('Promise', 'to be fulfilled [with]', function (expect, subject, value) {
+        this.errorMode = 'nested';
+        var flags = this.flags;
+        return subject.then(function (obj) {
+            if (flags['with'] || typeof value !== 'undefined') {
+                return expect(obj, 'to satisfy', value);
+            }
+        }, function (err) {
+            expect.fail(function (output) {
+                output.appendInspected(subject).sp().text('unexpectedly rejected');
+                if (typeof err !== 'undefined') {
+                    output.sp().text('with').sp().appendInspected(err);
+                }
+            });
+        });
+    });
+
+    expect.addAssertion('Promise', 'when rejected', function (expect, subject, nextAssertion) {
+        this.errorMode = 'nested';
+        var that = this;
+        return subject.then(function (obj) {
+            if (typeof nextAssertion === 'string') {
+                that.argsOutput = function (output) {
+                    output.error(nextAssertion);
+                    var rest = that.args.slice(1);
+                    if (rest.length > 0) {
+                        output.sp().appendItems(rest, ', ');
+                    }
+                };
+            }
+            expect.fail(function (output) {
+                output.appendInspected(subject).sp().text('unexpectedly fulfilled');
+                if (typeof obj !== 'undefined') {
+                    output.sp().text('with').sp().appendInspected(obj);
+                }
+            });
+        }, function (err) {
+            return that.shift(err, 0);
+        });
+    });
+
+    expect.addAssertion('Promise', 'when fulfilled', function (expect, subject, nextAssertion) {
+        this.errorMode = 'nested';
+        var that = this;
+        return subject.then(function (value) {
+            return that.shift(value, 0);
+        }, function (err) {
+            if (typeof nextAssertion === 'string') {
+                that.argsOutput = function (output) {
+                    output.error(nextAssertion);
+                    var rest = that.args.slice(1);
+                    if (rest.length > 0) {
+                        output.sp().appendItems(rest, ', ');
+                    }
+                };
+            }
+            expect.fail(function (output) {
+                output.appendInspected(subject).sp().text('unexpectedly rejected');
+                if (typeof err !== 'undefined') {
+                    output.sp().text('with').sp().appendInspected(err);
+                }
+            });
+        });
+    });
+
+    expect.addAssertion('function', [
+        'to call the callback (|without error|with error)'
+    ], function (expect, subject, expectedError) {
+        var testDescription = this.testDescription;
+        var alternation = this.alternations[0];
+        if (alternation === 'without error' && typeof expectedError !== 'undefined') {
+            throw new Error("The '" + testDescription + "' assertion does not support arguments");
+        }
+
+        this.errorMode = 'nested';
+        return expect.promise(function (run) {
+            var async = false;
+            var calledTwice = false;
+            var callbackArgs;
+            function cb() {
+                if (callbackArgs) {
+                    calledTwice = true;
+                } else {
+                    callbackArgs = arguments;
+                }
+                if (async) {
+                    setTimeout(assert, 0);
+                }
+            }
+
+            var assert = run(function () {
+                if (calledTwice) {
+                    expect.fail(function () {
+                        this.error('The callback was called twice');
+                    });
+                }
+                var err = callbackArgs[0];
+                if (alternation === '') {
+                    return Array.prototype.slice.call(callbackArgs);
+                } else if (alternation === 'without error') {
+                    if (err) {
+                        expect.fail(function (output) {
+                            output.error('called the callback with: ').appendErrorMessage(err);
+                        });
+                    }
+                    return Array.prototype.slice.call(callbackArgs, 1);
+                } else {
+                    // alternation === 'with error'
+                    if (typeof expectedError !== 'undefined') {
+                        if (err && err.isUnexpected && (typeof expectedError === 'string' || isRegExp(expectedError))) {
+                            return expect(err, 'to have text message', expectedError).then(function () {
+                                return err;
+                            });
+                        } else {
+                            return expect(err, 'to satisfy', expectedError).then(function () {
+                                return err;
+                            });
+                        }
+                    } else {
+                        expect(err, 'to be truthy');
+                    }
+                    return err;
+                }
+            });
+
+            subject(cb);
+            if (callbackArgs) {
+                assert();
+            }
+            async = true;
+        });
+    });
+};
+
+}).call(this,require(19).Buffer)
+},{}],5:[function(require,module,exports){
+module.exports = function createStandardErrorMessage(output, expect, subject, testDescription, args, options) {
+    options = options || {};
+    var preamble = 'expected';
+
+    var subjectOutput = output.clone();
+    if (subject) {
+        subject.call(subjectOutput, subjectOutput);
+    }
+
+    var argsOutput = output.clone();
+    if (typeof args === 'function') {
+        args.call(argsOutput, argsOutput);
+    } else {
+        if (args.length > 0) {
+            args.forEach(function (arg, index) {
+                if (0 < index) {
+                    argsOutput.text(', ');
+                }
+                arg.call(argsOutput, argsOutput);
+            });
+        }
+    }
+
+    var subjectSize = subjectOutput.size();
+    var argsSize = argsOutput.size();
+    var width = preamble.length + subjectSize.width + argsSize.width + testDescription.length;
+    var height = Math.max(subjectSize.height, argsSize.height);
+
+    if (options.compactSubject && subjectSize.height > 1) {
+        output.error('expected').sp();
+        options.compactSubject.call(output, output);
+        output.sp();
+    } else {
+        output.error(preamble);
+        if (subjectSize.height > 1) {
+            output.nl();
+        } else {
+            output.sp();
+        }
+        output.append(subjectOutput);
+        if (subjectSize.height > 1 || (height === 1 && width > 120)) {
+            output.nl();
+        } else {
+            output.sp();
+        }
+    }
+
+    output.error(testDescription);
+
+    if (argsSize.height > 1) {
+        output.nl();
+    } else if (argsSize.width > 0) {
+        output.sp();
+    }
+
+    output.append(argsOutput);
+
+    return output;
+};
+
+},{}],6:[function(require,module,exports){
+module.exports = function isPendingPromise(obj) {
+    return obj && typeof obj.then === 'function' && typeof obj.isPending === 'function' && obj.isPending();
+};
+
+},{}],7:[function(require,module,exports){
+/*global Promise:true*/
+var Promise = require(18);
+var oathbreaker = require(8);
+var throwIfNonUnexpectedError = require(11);
+
+function makePromise(body) {
+    if (typeof body !== 'function') {
+        throw new TypeError('expect.promise(...) requires a function argument to be supplied.\n' +
+                            'See http://unexpectedjs.github.io/api/promise/ for more details.');
+    }
+
+    if (body.length === 2) {
+        return new Promise(body);
+    }
+
+    return new Promise(function (resolve, reject) {
+        var runningTasks = 0;
+        var resolvedValue;
+
+        function fulfillIfDone() {
+            if (runningTasks === 0) {
+                resolve(resolvedValue);
+            }
+        }
+
+        function noteResolvedValue(value) {
+            if (typeof value !== 'undefined' && typeof resolvedValue === 'undefined') {
+                resolvedValue = value;
+            }
+        }
+
+        var runner = function (cb) {
+            runningTasks += 1;
+            return function () {
+                runningTasks -= 1;
+                try {
+                    var result = cb.apply(null, arguments);
+                    result = oathbreaker(result);
+                    if (isPromise(result)) {
+                        runningTasks += 1;
+                        result.then(function (value) {
+                            noteResolvedValue(value);
+                            runningTasks -= 1;
+                            fulfillIfDone();
+                        }, function (e) {
+                            reject(e);
+                        });
+                    } else {
+                        noteResolvedValue(result);
+                    }
+                } catch (e) {
+                    return reject(e);
+                }
+                fulfillIfDone();
+            };
+        };
+
+        try {
+            var result = oathbreaker(body(runner));
+            if (isPromise(result)) {
+                runningTasks += 1;
+                result.then(function (value) {
+                    noteResolvedValue(value);
+                    runningTasks -= 1;
+                    fulfillIfDone();
+                }, reject);
+            } else {
+                noteResolvedValue(result);
+            }
+        } catch (e) {
+            return reject(e);
+        }
+        fulfillIfDone();
+    });
+}
+
+function isPromise(obj) {
+    return obj && typeof obj === 'object' && typeof obj.then === 'function';
+}
+
+function extractPromisesFromObject(obj) {
+    if (isPromise(obj)) {
+        return [obj];
+    } else if (obj && typeof obj === 'object') {
+        var promises = [];
+        // Object or Array
+        Object.keys(obj).forEach(function (key) {
+            Array.prototype.push.apply(promises, extractPromisesFromObject(obj[key]));
+        });
+        return promises;
+    }
+    return [];
+}
+
+['all', 'any', 'settle'].forEach(function (staticMethodName) {
+    makePromise[staticMethodName] = function (obj) {
+        var result = Promise[staticMethodName](extractPromisesFromObject(obj));
+        if (staticMethodName === 'settle') {
+            return result.then(function (promises) {
+                promises.forEach(function (promise) {
+                    if (promise.isRejected()) {
+                        throwIfNonUnexpectedError(promise.reason());
+                    }
+                });
+                return promises;
+            });
+        }
+        return result;
+    };
+});
+
+['resolve', 'reject'].forEach(function (staticMethodName) {
+    makePromise[staticMethodName] = Promise[staticMethodName];
+});
+
+module.exports = makePromise;
+
+},{}],8:[function(require,module,exports){
+/*global Promise:true*/
+var workQueue = require(14);
+var Promise = require(18);
+module.exports = function oathbreaker(value) {
+    if (!value || typeof value.then !== 'function') {
+        return value;
+    }
+
+    if (!value.isRejected) {
+        // this is not a bluebird promise
+        return value;
+    }
+
+    if (value.isFulfilled()) {
+        return value;
+    }
+
+
+    if (value.isRejected()) {
+        value.caught(function () {
+            // Ignore - already handled
+        });
+
+        throw value.reason();
+    }
+
+    var onResolve = function () {};
+    var onReject = function () {};
+
+    var evaluated = false;
+    var error;
+    var resolvedValue;
+    value.then(function (obj) {
+        evaluated = true;
+        resolvedValue = obj;
+        onResolve(value);
+    }, function (err) {
+        evaluated = true;
+        error = err;
+        onReject(err);
+    });
+
+    workQueue.drain();
+
+    if (evaluated && error) {
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(error);
+        }
+        throw error;
+    } else if (evaluated) {
+        return value;
+    }
+
+    return new Promise(function (resolve, reject) {
+        onResolve = resolve;
+        onReject = reject;
+    });
+};
+
+},{}],9:[function(require,module,exports){
+module.exports = function (expect) {
+    expect.installTheme({
+        jsBoolean: 'jsPrimitive',
+        jsNumber: 'jsPrimitive',
+        error: ['red', 'bold'],
+        success: ['green', 'bold'],
+        diffAddedLine: 'green',
+        diffAddedHighlight: ['bgGreen', 'white'],
+        diffAddedSpecialChar: ['bgGreen', 'cyan', 'bold'],
+        diffRemovedLine: 'red',
+        diffRemovedHighlight: ['bgRed', 'white'],
+        diffRemovedSpecialChar: ['bgRed', 'cyan', 'bold'],
+        partialMatchHighlight: ['bgYellow']
+    });
+
+    expect.installTheme('html', {
+        jsComment: '#969896',
+        jsFunctionName: '#795da3',
+        jsKeyword: '#a71d5d',
+        jsPrimitive: '#0086b3',
+        jsRegexp: '#183691',
+        jsString: '#df5000',
+        jsKey: '#555'
+    });
+
+    expect.installTheme('ansi', {
+        jsComment: 'gray',
+        jsFunctionName: 'jsKeyword',
+        jsKeyword: 'magenta',
+        jsNumber: [],
+        jsPrimitive: 'cyan',
+        jsRegexp: 'green',
+        jsString: 'cyan',
+        jsKey: '#666',
+        diffAddedHighlight: ['bgGreen', 'black'],
+        diffRemovedHighlight: ['bgRed', 'black'],
+        partialMatchHighlight: ['bgYellow', 'black']
+    });
+
+    expect.addStyle('singleQuotedString', function (content) {
+        content = String(content);
+        this.jsString("'")
+            .jsString(content.replace(/[\\\x00-\x1f']/g, function ($0) {
+                if ($0 === '\n') {
+                    return '\\n';
+                } else if ($0 === '\r') {
+                    return '\\r';
+                } else if ($0 === "'") {
+                    return "\\'";
+                } else if ($0 === '\\') {
+                    return '\\\\';
+                } else if ($0 === '\t') {
+                    return '\\t';
+                } else if ($0 === '\b') {
+                    return '\\b';
+                } else if ($0 === '\f') {
+                    return '\\f';
+                } else {
+                    var charCode = $0.charCodeAt(0);
+                    return '\\x' + (charCode < 16 ? '0' : '') + charCode.toString(16);
+                }
+            }))
+            .jsString("'");
+    });
+
+    expect.addStyle('key', function (content) {
+        content = String(content);
+        if (/^[a-z\$\_][a-z0-9\$\_]*$/i.test(content)) {
+            this.text(content, 'jsKey');
+        } else if (/^(?:0|[1-9][0-9]*)$/.test(content)) {
+            this.jsNumber(content);
+        } else {
+            this.singleQuotedString(content);
+        }
+    });
+
+    // Intended to be redefined by a plugin that offers syntax highlighting:
+    expect.addStyle('code', function (content, language) {
+        this.text(content);
+    });
+
+    expect.addStyle('annotationBlock', function () {
+        var pen = this.getContentFromArguments(arguments);
+        var height = pen.size().height;
+
+        if (height > 0) {
+            this.block(function () {
+                for (var i = 0; i < height; i += 1) {
+                    if (0 < i) {
+                        this.nl();
+                    }
+                    this.error('//');
+                }
+            });
+            this.sp().block(pen);
+        }
+    });
+
+    expect.addStyle('removedHighlight', function (content) {
+        this.alt({
+            text: function () {
+                this.block(function () {
+                    this.text(content).nl().text(content.replace(/[\s\S]/g, '^'));
+                });
+            },
+            fallback: function () {
+                this.diffRemovedHighlight(content);
+            }
+        });
+    });
+
+    expect.addStyle('match', function (content) {
+        this.alt({
+            text: function () {
+                this.block(function () {
+                    this.text(content).nl().text(content.replace(/[\s\S]/g, '^'));
+                });
+            },
+            fallback: function () {
+                this.diffAddedHighlight(content);
+            }
+        });
+    });
+
+    expect.addStyle('partialMatch', function (content) {
+        this.alt({
+            text: function () {
+                this.block(function () {
+                    this.text(content).nl().text(content.replace(/[\s\S]/g, '^').substr(0, content.length - 1) + '>');
+                });
+            },
+            fallback: function () {
+                this.partialMatchHighlight(content);
+            }
+        });
+    });
+
+    expect.addStyle('shouldEqualError', function (expected) {
+        this.error(typeof expected === 'undefined' ? 'should be' : 'should equal').sp().block(function () {
+            this.appendInspected(expected);
+        });
+    });
+
+    expect.addStyle('errorName', function (error) {
+        if (typeof error.name === 'string' && error.name !== 'Error') {
+            this.text(error.name);
+        } else if (error.constructor && typeof error.constructor.name === 'string') {
+            this.text(error.constructor.name);
+        } else {
+            this.text('Error');
+        }
+    });
+
+    expect.addStyle('appendErrorMessage', function (error) {
+        if (error && error.isUnexpected) {
+            this.append(error.getErrorMessage(this));
+        } else {
+            this.appendInspected(error);
+        }
+    });
+
+    expect.addStyle('appendItems', function (items, separator) {
+        var that = this;
+        separator = separator || '';
+        items.forEach(function (item, index) {
+            if (0 < index) {
+                that.append(separator);
+            }
+            that.appendInspected(item);
+        });
+    });
+};
+
+},{}],10:[function(require,module,exports){
+/*global it:true, jasmine, mocha*/
+function isMochaModule(module) {
+    return module && (
+        (module.exports && module.exports.name === 'Mocha') ||
+            (/(\/mocha\.js|_mocha)$/).test(module.filename)
+    );
+}
+
+function isVanillaMocha() {
+    var currentModule = typeof module !== 'undefined' && module;
+    while (currentModule) {
+        if (isMochaModule(currentModule)) {
+            return true;
+        } else {
+            currentModule = currentModule.parent;
+        }
+    }
+    return false;
+}
+
+function jasmineFail(err) {
+    if (typeof jasmine === 'object') {
+        jasmine.getEnv().fail(err);
+    }
+}
+
+function jasmineSuccess(err) {
+    if (typeof jasmine === 'object') {
+        jasmine.getEnv().expect(true).toBe(true);
+    }
+}
+
+var promiseCreated = false;
+
+var shouldApplyPatch =
+    typeof mocha !== 'undefined' ||
+    (typeof jasmine !== 'undefined' && typeof jasmine.version === 'string' && jasmine.version.match(/^2\./)) ||
+    isVanillaMocha();
+
+module.exports = {
+    promiseCreated: function () {
+        promiseCreated = true;
+    },
+    applyPatch: function () {
+        if (typeof it === 'undefined' || it.patchApplied) {
+            return;
+        }
+
+        if (shouldApplyPatch) {
+            var originalIt = it;
+            it = function (title, fn) {
+                if (!fn) {
+                    return originalIt(title);
+                }
+                var async = fn.length > 0;
+                var wrapper = function (done) {
+                    promiseCreated = false;
+                    var result;
+                    try {
+                        if (async) {
+                            fn.call(this, function (err) {
+                                if (err) {
+                                    jasmineFail(err);
+                                    done(err);
+                                } else {
+                                    jasmineSuccess();
+                                    done();
+                                }
+                            });
+                            return;
+                        } else {
+                            result = fn.call(this);
+                        }
+                        var isPromise = result && typeof result === 'object' && typeof result.then === 'function';
+                        if (isPromise) {
+                            result.then(function () {
+                                jasmineSuccess();
+                                done();
+                            }, function (err) {
+                                jasmineFail(err);
+                                done(err);
+                            });
+                        } else if (promiseCreated) {
+                            throw new Error('When using asynchronous assertions you must return a promise from the it block');
+                        } else {
+                            jasmineSuccess();
+                            done();
+                        }
+                    } catch (err) {
+                        jasmineFail(err);
+                        return done(err);
+                    }
+                };
+                wrapper.toString = function () {
+                    return fn.toString();
+                };
+                return originalIt(title, wrapper);
+            };
+            Object.keys(originalIt).forEach(function (methodName) {
+                it[methodName] = originalIt[methodName];
+            });
+            it.patchApplied = true;
+        }
+    }
+};
+
+},{}],11:[function(require,module,exports){
+module.exports = function throwIfNonUnexpectedError(err) {
+    if (err && err.message === 'aggregate error') {
+        for (var i = 0 ; i < err.length ; i += 1) {
+            throwIfNonUnexpectedError(err[i]);
+        }
+    } else if (!err || !err._isUnexpected) {
+        throw err;
+    }
+};
+
+},{}],12:[function(require,module,exports){
+(function (Buffer){
+var utils = require(13);
+var isRegExp = utils.isRegExp;
+var leftPad = utils.leftPad;
+var arrayChanges = require(16);
+var leven = require(25);
+
+module.exports = function (expect) {
+    expect.addType({
+        name: 'wrapperObject',
+        identify: false,
+        equal: function (a, b, equal) {
+            return a === b || equal(this.unwrap(a), this.unwrap(b));
+        },
+        inspect: function (value, depth, output, inspect) {
+            output.append(this.prefix(output.clone(), value));
+            output.append(inspect(this.unwrap(value), depth));
+            output.append(this.suffix(output.clone(), value));
+        },
+        diff: function (actual, expected, output, diff, inspect) {
+            actual = this.unwrap(actual);
+            expected = this.unwrap(expected);
+            var comparison = diff(actual, expected);
+            var prefixOutput = this.prefix(output.clone(), actual);
+            var suffixOutput = this.suffix(output.clone(), actual);
+            if (comparison && comparison.inline) {
+                return {
+                    inline: true,
+                    diff: output.append(prefixOutput).append(comparison.diff).append(suffixOutput)
+                };
+            } else {
+                return {
+                    inline: true,
+                    diff: output.append(prefixOutput).nl()
+                        .indentLines()
+                        .i().block(function () {
+                            this.append(inspect(actual)).sp().annotationBlock(function () {
+                                this.shouldEqualError(expected, inspect);
+                                if (comparison) {
+                                    this.nl().append(comparison.diff);
+                                }
+                            });
+                        }).nl()
+                        .outdentLines()
+                        .append(suffixOutput)
+                };
+            }
+        }
+    });
+
+    expect.addType({
+        name: 'object',
+        identify: function (obj) {
+            return obj && (typeof obj === 'object' || typeof obj === 'function');
+        },
+        prefix: function (output, obj) {
+            var constructor = obj.constructor;
+            var constructorName = constructor && constructor !== Object && utils.getFunctionName(constructor);
+            if (constructorName && constructorName !== 'Object') {
+                output.text(constructorName + '(');
+            }
+            return output.text('{');
+        },
+        suffix: function (output, obj) {
+            output.text('}');
+            var constructor = obj.constructor;
+            var constructorName = constructor && constructor !== Object && utils.getFunctionName(constructor);
+            if (constructorName && constructorName !== 'Object') {
+                output.text(')');
+            }
+            return output;
+        },
+        getKeys: Object.keys,
+        equal: function (a, b, equal) {
+            if (a === b) {
+                return true;
+            }
+
+            if (b.constructor !== a.constructor) {
+                return false;
+            }
+
+            var actualKeys = expect.findTypeOf(a).getKeys(a).filter(function (key) {
+                    return typeof a[key] !== 'undefined';
+                }),
+                expectedKeys = expect.findTypeOf(b).getKeys(b).filter(function (key) {
+                    return typeof b[key] !== 'undefined';
+                });
+
+            // having the same number of owned properties (keys incorporates hasOwnProperty)
+            if (actualKeys.length !== expectedKeys.length) {
+                return false;
+            }
+            //the same set of keys (although not necessarily the same order),
+            actualKeys.sort();
+            expectedKeys.sort();
+            // cheap key test
+            for (var i = 0; i < actualKeys.length; i += 1) {
+                if (actualKeys[i] !== expectedKeys[i]) {
+                    return false;
+                }
+            }
+
+            //equivalent values for every corresponding key, and
+            // possibly expensive deep test
+            for (var j = 0; j < actualKeys.length; j += 1) {
+                var key = actualKeys[j];
+                if (!equal(a[key], b[key])) {
+                    return false;
+                }
+            }
+            return true;
+        },
+        inspect: function (obj, depth, output, inspect) {
+            var keys = this.getKeys(obj);
+            if (keys.length === 0) {
+                this.prefix(output, obj);
+                this.suffix(output, obj);
+                return output;
+            }
+            var inspectedItems = keys.map(function (key, index) {
+                var lastIndex = index === keys.length - 1;
+
+                var propertyDescriptor = Object.getOwnPropertyDescriptor && Object.getOwnPropertyDescriptor(obj, key);
+                var hasGetter = propertyDescriptor && propertyDescriptor.get;
+                var hasSetter = propertyDescriptor && propertyDescriptor.set;
+                var propertyOutput = output.clone();
+                if (hasSetter && !hasGetter) {
+                    propertyOutput.text('set').sp();
+                }
+                propertyOutput.key(key);
+                propertyOutput.text(':');
+
+                // Inspect the setter function if there's no getter:
+                var value = (hasSetter && !hasGetter) ? hasSetter : obj[key];
+                var inspectedValue = inspect(value);
+
+                if (!lastIndex) {
+                    inspectedValue.amend('text', ',');
+                }
+
+                if (inspectedValue.isBlock() && inspectedValue.isMultiline()) {
+                    propertyOutput.indentLines();
+                    propertyOutput.nl().i();
+                } else {
+                    propertyOutput.sp();
+                }
+
+                if (value && value._expectIt) {
+                    propertyOutput.block(inspectedValue);
+                } else {
+                    propertyOutput.append(inspectedValue);
+                }
+                if (hasGetter && hasSetter) {
+                    propertyOutput.sp().jsComment('/* getter/setter */');
+                } else if (hasGetter) {
+                    propertyOutput.sp().jsComment('/* getter */');
+                }
+
+                return propertyOutput;
+            });
+
+            var maxLineLength = output.preferredWidth - (depth === Infinity ? 0 : depth) * 2 - 2;
+            var width = 0;
+            var compact = inspectedItems.length > 5 || inspectedItems.every(function (inspectedItem) {
+                if (inspectedItem.isMultiline()) {
+                    return false;
+                }
+                width += inspectedItem.size().width;
+                return width < maxLineLength;
+            });
+
+            var itemsOutput = output.clone();
+            if (compact) {
+                var currentLineLength = 0;
+                inspectedItems.forEach(function (inspectedItem, index) {
+                    var size = inspectedItem.size();
+                    currentLineLength += size.width + 1;
+                    if (index > 0) {
+                        if (size.height === 1 && currentLineLength < maxLineLength) {
+                            itemsOutput.sp();
+                        } else {
+                            itemsOutput.nl();
+                            currentLineLength = size.width;
+                        }
+
+                        if (size.height > 1) {
+                            // Make sure that we don't append more to this line
+                            currentLineLength = maxLineLength;
+                        }
+                    }
+                    itemsOutput.append(inspectedItem);
+                });
+            } else {
+                inspectedItems.forEach(function (inspectedItem, index) {
+                    if (index > 0) {
+                        itemsOutput.nl();
+                    }
+                    itemsOutput.append(inspectedItem);
+                });
+            }
+
+            this.prefix(output, obj);
+            if (itemsOutput.isMultiline()) {
+                output.nl()
+                      .indentLines()
+                      .i().block(itemsOutput)
+                      .outdentLines()
+                      .nl();
+            } else {
+                output.sp().append(itemsOutput).sp();
+            }
+            this.suffix(output, obj);
+        },
+        diff: function (actual, expected, output, diff, inspect, equal) {
+            if (actual.constructor !== expected.constructor) {
+                return {
+                    diff: output.text('Mismatching constructors ')
+                        .text(actual.constructor && utils.getFunctionName(actual.constructor) || actual.constructor)
+                        .text(' should be ').text(expected.constructor && utils.getFunctionName(expected.constructor) || expected.constructor),
+                    inline: false
+                };
+            }
+
+            var result = {
+                diff: output,
+                inline: true
+            };
+
+            var keyIndex = {};
+            expect.findTypeOf(actual).getKeys(actual).concat(expect.findTypeOf(expected).getKeys(expected)).forEach(function (key) {
+                if (!(key in keyIndex)) {
+                    keyIndex[key] = key;
+                }
+            });
+
+            var keys = Object.keys(keyIndex);
+
+            this.prefix(output, actual);
+            output.nl().indentLines();
+
+            keys.forEach(function (key, index) {
+                output.i().block(function () {
+                    var valueOutput;
+                    var annotation = output.clone();
+                    var conflicting = !equal(actual[key], expected[key]);
+                    var isInlineDiff = false;
+                    if (conflicting) {
+                        if (!(key in expected)) {
+                            annotation.error('should be removed');
+                            isInlineDiff = true;
+                        } else {
+                            var keyDiff = diff(actual[key], expected[key]);
+                            if (!keyDiff || (keyDiff && !keyDiff.inline)) {
+                                annotation.shouldEqualError(expected[key]);
+
+                                if (keyDiff) {
+                                    annotation.nl().append(keyDiff.diff);
+                                }
+                            } else {
+                                isInlineDiff = true;
+                                valueOutput = keyDiff.diff;
+                            }
+                        }
+                    } else {
+                        isInlineDiff = true;
+                    }
+
+                    var last = index === keys.length - 1;
+                    if (!valueOutput) {
+                        valueOutput = inspect(actual[key], conflicting ? Infinity : 1);
+                    }
+
+                    this.key(key);
+                    this.text(':');
+                    valueOutput.amend('text', last ? '' : ',');
+                    if (valueOutput.isBlock() && valueOutput.isMultiline()) {
+                        this.indentLines();
+                        this.nl().i();
+                    } else {
+                        this.sp();
+                    }
+
+                    if (isInlineDiff) {
+                        this.append(valueOutput);
+                    } else {
+                        this.block(valueOutput);
+                    }
+                    if (!annotation.isEmpty()) {
+                        this.sp().annotationBlock(annotation);
+                    }
+                }).nl();
+            });
+
+            output.outdentLines();
+            this.suffix(output, actual);
+
+            return result;
+        }
+    });
+
+    function structurallySimilar(a, b) {
+        var typeA = typeof a;
+        var typeB = typeof b;
+
+        if (typeA !== typeB) {
+            return false;
+        }
+
+        if (typeA === 'string') {
+            return leven(a, b) < a.length / 2;
+        }
+
+        if (typeA !== 'object' || !a) {
+            return false;
+        }
+
+        if (utils.isArray(a) && utils.isArray(b)) {
+            return true;
+        }
+
+        var aKeys = expect.findTypeOf(a).getKeys(a);
+        var bKeys = expect.findTypeOf(b).getKeys(b);
+        var numberOfSimilarKeys = 0;
+        var requiredSimilarKeys = Math.round(Math.max(aKeys.length, bKeys.length) / 2);
+        return aKeys.concat(bKeys).some(function (key) {
+            if (key in a && key in b) {
+                numberOfSimilarKeys += 1;
+            }
+
+            return numberOfSimilarKeys >= requiredSimilarKeys;
+        });
+    }
+
+    expect.addType({
+        name: 'array-like',
+        base: 'object',
+        identify: false,
+        getKeys: function (obj) {
+            var keys = new Array(obj.length);
+            for (var i = 0 ; i < obj.length ; i += 1) {
+                keys[i] = i;
+            }
+            return keys;
+        },
+        equal: function (a, b, equal) {
+            if (a === b) {
+                return true;
+            } else if (a.constructor === b.constructor && a.length === b.length) {
+                for (var i = 0; i < a.length; i += 1) {
+                    if (!equal(a[i], b[i])) {
+                        return false;
+                    }
+                }
+                return true;
+            } else {
+                return false;
+            }
+        },
+        prefix: function (output) {
+            return output.text('[');
+        },
+        suffix: function (output) {
+            return output.text(']');
+        },
+        inspect: function (arr, depth, output, inspect) {
+            var prefixOutput = this.prefix(output.clone(), arr);
+            var suffixOutput = this.suffix(output.clone(), arr);
+            if (arr.length === 0) {
+                return output.append(prefixOutput).append(suffixOutput);
+            }
+
+            if (depth === 1) {
+                return output.append(prefixOutput).text('...').append(suffixOutput);
+            }
+
+            var inspectedItems = this.getKeys(arr).map(function (key) {
+                return key in arr ? inspect(arr[key]) : output.clone();
+            });
+
+            var maxLineLength = output.preferredWidth - (depth === Infinity ? 0 : depth) * 2 - 2;
+            var width = 0;
+            var multipleLines = inspectedItems.some(function (o) {
+                if (o.isMultiline()) {
+                    return true;
+                }
+
+                var size = o.size();
+                width += size.width;
+                return width > maxLineLength;
+            });
+
+            inspectedItems.forEach(function (inspectedItem, index) {
+                var lastIndex = index === inspectedItems.length - 1;
+                if (!lastIndex) {
+                    inspectedItem.amend('text', ',');
+                }
+            });
+
+            if (multipleLines) {
+                output.append(prefixOutput).nl().indentLines();
+
+                inspectedItems.forEach(function (inspectedItem, index) {
+                    output.i().block(inspectedItem).nl();
+                });
+
+                output.outdentLines().append(suffixOutput);
+            } else {
+                output.append(prefixOutput).sp();
+                inspectedItems.forEach(function (inspectedItem, index) {
+                    output.append(inspectedItem);
+                    var lastIndex = index === inspectedItems.length - 1;
+                    if (!lastIndex) {
+                        output.sp();
+                    }
+                });
+                output.sp().append(suffixOutput);
+            }
+        },
+        diffLimit: 512,
+        diff: function (actual, expected, output, diff, inspect, equal) {
+            var result = {
+                diff: output,
+                inline: true
+            };
+
+            if (Math.max(actual.length, expected.length) > this.diffLimit) {
+                result.diff.jsComment('Diff suppressed due to size > ' + this.diffLimit);
+                return result;
+            }
+
+            if (actual.constructor !== expected.constructor) {
+                return this.baseType.diff(actual, expected, output);
+            }
+
+            var changes = arrayChanges(actual, expected, equal, structurallySimilar);
+
+            output.append(this.prefix(output.clone(), actual)).nl().indentLines();
+
+            changes.forEach(function (diffItem, index) {
+                output.i().block(function () {
+                    var type = diffItem.type;
+                    var last = !!diffItem.last;
+
+                    if (type === 'insert') {
+                        this.annotationBlock(function () {
+                            this.error('missing ').block(inspect(diffItem.value));
+                        });
+                    } else if (type === 'remove') {
+                        this.block(inspect(diffItem.value).amend('text', last ? ' ' : ', ').error('// should be removed'));
+                    } else if (type === 'equal') {
+                        this.block(inspect(diffItem.value).amend('text', last ? '' : ','));
+                    } else {
+                        var valueDiff = diff(diffItem.value, diffItem.expected);
+                        if (valueDiff && valueDiff.inline) {
+                            this.block(valueDiff.diff.amend('text', last ? '' : ','));
+                        } else if (valueDiff) {
+                            this.block(inspect(diffItem.value).amend('text', last ? ' ' : ', ')).annotationBlock(function () {
+                                this.shouldEqualError(diffItem.expected, inspect).nl().append(valueDiff.diff);
+                            });
+                        } else {
+                            this.block(inspect(diffItem.value).amend('text', last ? ' ' : ', ')).annotationBlock(function () {
+                                this.shouldEqualError(diffItem.expected, inspect);
+                            });
+                        }
+                    }
+                }).nl();
+            });
+
+            output.outdentLines().append(this.suffix(output.clone(), actual));
+
+            return result;
+        }
+    });
+
+    expect.addType({
+        name: 'array',
+        base: 'array-like',
+        identify: function (arr) {
+            return utils.isArray(arr);
+        }
+    });
+
+    expect.addType({
+        name: 'arguments',
+        base: 'array-like',
+        prefix: function (output) {
+            return output.text('arguments(', 'cyan');
+        },
+        suffix: function (output) {
+            return output.text(')', 'cyan');
+        },
+        identify: function (obj) {
+            return Object.prototype.toString.call(obj) === '[object Arguments]';
+        }
+    });
+
+    var errorMethodBlacklist = ['message', 'name', 'description', 'line', 'column', 'sourceId', 'sourceURL', 'stack', 'stackArray'].reduce(function (result, prop) {
+        result[prop] = true;
+        return result;
+    }, {});
+
+    expect.addType({
+        base: 'object',
+        name: 'Error',
+        identify: function (value) {
+            return utils.isError(value);
+        },
+        getKeys: function (value) {
+            var keys = this.baseType.getKeys(value).filter(function (key) {
+                return !errorMethodBlacklist[key];
+            });
+            keys.unshift('message');
+            return keys;
+        },
+        unwrap: function (value) {
+            return this.getKeys(value).reduce(function (result, key) {
+                result[key] = value[key];
+                return result;
+            }, {});
+        },
+        equal: function (a, b, equal) {
+            return a === b ||
+                (equal(a.message, b.message) && this.baseType.equal(a, b));
+        },
+        inspect: function (value, depth, output, inspect) {
+            output.errorName(value).text('(');
+            var keys = this.getKeys(value);
+            if (keys.length === 1 && keys[0] === 'message') {
+                if (value.message !== '') {
+                    output.append(inspect(value.message));
+                }
+            } else {
+                output.append(inspect(this.unwrap(value), depth));
+            }
+            output.text(')');
+        },
+        diff: function (actual, expected, output, diff) {
+            if (actual.constructor !== expected.constructor) {
+                return {
+                    diff: output.text('Mismatching constructors ')
+                        .errorName(actual)
+                        .text(' should be ').errorName(expected),
+                    inline: false
+                };
+            }
+
+            var result = diff(this.unwrap(actual), this.unwrap(expected));
+            if (result.diff) {
+                result.diff = output.clone().errorName(actual).text('(').append(result.diff).text(')');
+
+            }
+            return result;
+        }
+    });
+
+    var unexpectedErrorMethodBlacklist = ['output', '_isUnexpected', 'htmlMessage', '_hasSerializedErrorMessage', 'expect', 'assertion'].reduce(function (result, prop) {
+        result[prop] = true;
+        return result;
+    }, {});
+    expect.addType({
+        base: 'Error',
+        name: 'UnexpectedError',
+        identify: function (value) {
+            return value && typeof value === 'object' &&
+                value._isUnexpected && this.baseType.identify(value);
+        },
+        getKeys: function (value) {
+            return this.baseType.getKeys(value).filter(function (key) {
+                return !unexpectedErrorMethodBlacklist[key];
+            });
+        },
+        inspect: function (value, depth, output) {
+            output.jsFunctionName(this.name).text('(');
+            var errorMessage = value.getErrorMessage(output);
+            if (errorMessage.isMultiline()) {
+                output.nl().indentLines().i().block(errorMessage).nl();
+            } else {
+                output.append(errorMessage);
+            }
+            output.text(')');
+        }
+    });
+
+    expect.addType({
+        name: 'date',
+        identify: function (obj) {
+            return Object.prototype.toString.call(obj) === '[object Date]';
+        },
+        equal: function (a, b) {
+            return a.getTime() === b.getTime();
+        },
+        inspect: function (date, depth, output, inspect) {
+            // TODO: Inspect "new" as an operator and Date as a built-in once we have the styles defined:
+            var dateStr = date.toUTCString().replace(/UTC/, 'GMT');
+            var milliseconds = date.getUTCMilliseconds();
+            if (milliseconds > 0) {
+                var millisecondsStr = String(milliseconds);
+                while (millisecondsStr.length < 3) {
+                    millisecondsStr = '0' + millisecondsStr;
+                }
+                dateStr = dateStr.replace(' GMT', '.' + millisecondsStr + ' GMT');
+            }
+
+            output.jsKeyword('new').sp().text('Date(').append(inspect(dateStr).text(')'));
+        }
+    });
+
+    expect.addType({
+        base: 'object',
+        name: 'function',
+        identify: function (f) {
+            return typeof f === 'function';
+        },
+        equal: function (a, b) {
+            return a === b || a.toString() === b.toString();
+        },
+        inspect: function (f, depth, output, inspect) {
+            var source = f.toString();
+            var name = utils.getFunctionName(f) || '';
+            var args;
+            var body;
+            var matchSource = source.match(/^\s*function \w*?\s*\(([^\)]*)\)\s*\{([\s\S]*?( *)?)\}\s*$/);
+            if (matchSource) {
+                args = matchSource[1];
+                body = matchSource[2];
+                var bodyIndent = matchSource[3] || '';
+                // Remove leading indentation unless the function is a one-liner or it uses multiline string literals
+                if (/\n/.test(body) && !/\\\n/.test(body)) {
+                    body = body.replace(new RegExp('^ {' + bodyIndent.length + '}', 'mg'), '');
+                }
+                if (!name || name === 'anonymous') {
+                    name = '';
+                }
+                if (/^\s*\[native code\]\s*$/.test(body)) {
+                    body = ' /* native code */ ';
+                } else {
+                    body = body.replace(/^((?:.*\n){3}( *).*\n)[\s\S]*?\n[\s\S]*?\n((?:.*\n){3})$/, '$1$2// ... lines removed ...\n$3');
+                }
+            } else {
+                args = ' /*...*/ ';
+                body = ' /*...*/ ';
+            }
+            output.code('function ' + name + '(' + args + ') {' + body + '}', 'javascript');
+        }
+    });
+
+    expect.addType({
+        base: 'function',
+        name: 'expect.it',
+        identify: function (f) {
+            return typeof f === 'function' && f._expectIt;
+        },
+        inspect: function (f, depth, output, inspect) {
+            output.text('expect.it(');
+            var orBranch = false;
+            f._expectations.forEach(function (expectation, index) {
+                if (expectation === f._OR) {
+                    orBranch = true;
+                    return;
+                }
+
+                if (orBranch) {
+                    output.text(')\n      .or(');
+                } else if (0 < index) {
+                    output.text(')\n        .and(');
+                }
+
+                var args = Array.prototype.slice.call(expectation);
+                args.forEach(function (arg, i) {
+                    if (0 < i) {
+                        output.text(', ');
+                    }
+                    output.append(inspect(arg));
+                });
+                orBranch = false;
+            });
+
+            output.text(')');
+        }
+    });
+
+    expect.addType({
+        name: 'Promise',
+        base: 'object',
+        identify: function (obj) {
+            return obj && this.baseType.identify(obj) && typeof obj.then === 'function';
+        },
+        inspect: function (promise, depth, output, inspect) {
+            output.jsFunctionName('Promise');
+            if (promise.isPending && promise.isPending()) {
+                output.sp().yellow('(pending)');
+            } else if (promise.isFulfilled && promise.isFulfilled()) {
+                output.sp().green('(fulfilled)');
+                if (promise.value) {
+                    var value = promise.value();
+                    if (typeof value !== 'undefined') {
+                        output.sp().text('=>').sp().append(inspect(value));
+                    }
+                }
+            } else if (promise.isRejected && promise.isRejected()) {
+                output.sp().red('(rejected)');
+                var reason = promise.reason();
+                if (typeof reason !== 'undefined') {
+                    output.sp().text('=>').sp().append(inspect(promise.reason()));
+                }
+            }
+        }
+    });
+
+    expect.addType({
+        name: 'regexp',
+        identify: isRegExp,
+        equal: function (a, b) {
+            return a === b || (
+                a.source === b.source &&
+                    a.global === b.global &&
+                    a.ignoreCase === b.ignoreCase &&
+                    a.multiline === b.multiline
+            );
+        },
+        inspect: function (regExp, depth, output) {
+            output.jsRegexp(regExp);
+        }
+    });
+
+    expect.addType({
+        name: 'binaryArray',
+        base: 'array-like',
+        digitWidth: 2,
+        hexDumpWidth: 16,
+        identify: false,
+        prefix: function (output) {
+            output.code(this.name + '([', 'javascript');
+        },
+        suffix: function (output) {
+            output.code('])', 'javascript');
+        },
+        equal: function (a, b) {
+            if (a === b) {
+                return true;
+            }
+
+            if (a.length !== b.length) return false;
+
+            for (var i = 0; i < a.length; i += 1) {
+                if (a[i] !== b[i]) return false;
+            }
+
+            return true;
+        },
+        hexDump: function (obj, maxLength) {
+            var hexDump = '';
+            if (typeof maxLength !== 'number' || maxLength === 0) {
+                maxLength = obj.length;
+            }
+            for (var i = 0 ; i < maxLength ; i += this.hexDumpWidth) {
+                if (hexDump.length > 0) {
+                    hexDump += '\n';
+                }
+                var hexChars = '',
+                    asciiChars = ' │';
+
+                for (var j = 0 ; j < this.hexDumpWidth ; j += 1) {
+                    if (i + j < maxLength) {
+                        var octet = obj[i + j];
+                        hexChars += leftPad(octet.toString(16).toUpperCase(), this.digitWidth, '0') + ' ';
+                        asciiChars += String.fromCharCode(octet).replace(/\n/g, '␊').replace(/\r/g, '␍');
+                    } else if (this.digitWidth === 2) {
+                        hexChars += '   ';
+                    }
+                }
+
+                if (this.digitWidth === 2) {
+                    hexDump += hexChars + asciiChars + '│';
+                } else {
+                    hexDump += hexChars.replace(/\s+$/, '');
+                }
+            }
+            return hexDump;
+        },
+        inspect: function (obj, depth, output) {
+            this.prefix(output, obj);
+            var codeStr = '';
+            for (var i = 0 ; i < Math.min(this.hexDumpWidth, obj.length) ; i += 1) {
+                if (i > 0) {
+                    codeStr += ', ';
+                }
+                var octet = obj[i];
+                codeStr += '0x' + leftPad(octet.toString(16).toUpperCase(), this.digitWidth, '0');
+            }
+            if (obj.length > this.hexDumpWidth) {
+                codeStr += ' /* ' + (obj.length - this.hexDumpWidth) + ' more */ ';
+            }
+            output.code(codeStr, 'javascript');
+            this.suffix(output, obj);
+        },
+        diffLimit: 512,
+        diff: function (actual, expected, output, diff, inspect) {
+            var result = {diff: output};
+            if (Math.max(actual.length, expected.length) > this.diffLimit) {
+                result.diff.jsComment('Diff suppressed due to size > ' + this.diffLimit);
+            } else {
+                result.diff = utils.diffStrings(this.hexDump(actual), this.hexDump(expected), output, {type: 'Chars', markUpSpecialCharacters: false})
+                    .replaceText(/[\x00-\x1f\x7f-\xff␊␍]/g, '.').replaceText(/[│ ]/g, function (styles, content) {
+                        this.text(content);
+                    });
+            }
+            return result;
+        }
+    });
+
+    if (typeof Buffer !== 'undefined') {
+        expect.addType({
+            name: 'Buffer',
+            base: 'binaryArray',
+            identify: Buffer.isBuffer
+        });
+    }
+
+    [8, 16, 32].forEach(function (numBits) {
+        ['Int', 'Uint'].forEach(function (intOrUint) {
+            var constructorName = intOrUint + numBits + 'Array',
+                Constructor = this[constructorName];
+            if (typeof Constructor !== 'undefined') {
+                expect.addType({
+                    name: constructorName,
+                    base: 'binaryArray',
+                    hexDumpWidth: 128 / numBits,
+                    digitWidth: numBits / 4,
+                    identify: function (obj) {
+                        return obj instanceof Constructor;
+                    }
+                });
+            }
+        }, this);
+    }, this);
+
+    expect.addType({
+        name: 'string',
+        identify: function (value) {
+            return typeof value === 'string';
+        },
+        inspect: function (value, depth, output) {
+            output.singleQuotedString(value);
+        },
+        diff: function (actual, expected, output, diff, inspect) {
+            var result = {
+                diff: output,
+                inline: false
+            };
+            utils.diffStrings(actual, expected, output, {type: 'WordsWithSpace', markUpSpecialCharacters: true});
+            return result;
+        }
+    });
+
+    expect.addType({
+        name: 'number',
+        identify: function (value) {
+            return typeof value === 'number';
+        },
+        inspect: function (value, depth, output) {
+            if (value === 0 && 1 / value === -Infinity) {
+                value = '-0';
+            } else {
+                value = String(value);
+            }
+            output.jsNumber(String(value));
+        }
+    });
+
+    expect.addType({
+        name: 'NaN',
+        identify: function (value) {
+            return typeof value === 'number' && isNaN(value);
+        },
+        inspect: function (value, depth, output) {
+            output.jsPrimitive(value);
+        }
+    });
+
+    expect.addType({
+        name: 'boolean',
+        identify: function (value) {
+            return typeof value === 'boolean';
+        },
+        inspect: function (value, depth, output) {
+            output.jsPrimitive(value);
+        }
+    });
+
+    expect.addType({
+        name: 'undefined',
+        identify: function (value) {
+            return typeof value === 'undefined';
+        },
+        inspect: function (value, depth, output) {
+            output.jsPrimitive(value);
+        }
+    });
+
+    expect.addType({
+        name: 'null',
+        identify: function (value) {
+            return value === null;
+        },
+        inspect: function (value, depth, output) {
+            output.jsPrimitive(value);
+        }
+    });
+};
+
+}).call(this,require(19).Buffer)
+},{}],13:[function(require,module,exports){
+var stringDiff = require(24);
+
+var specialCharRegexp = /([\x00-\x09\x0B-\x1F\x7F-\x9F\xAD\u0378\u0379\u037F-\u0383\u038B\u038D\u03A2\u0528-\u0530\u0557\u0558\u0560\u0588\u058B-\u058E\u0590\u05C8-\u05CF\u05EB-\u05EF\u05F5-\u0605\u061C\u061D\u06DD\u070E\u070F\u074B\u074C\u07B2-\u07BF\u07FB-\u07FF\u082E\u082F\u083F\u085C\u085D\u085F-\u089F\u08A1\u08AD-\u08E3\u08FF\u0978\u0980\u0984\u098D\u098E\u0991\u0992\u09A9\u09B1\u09B3-\u09B5\u09BA\u09BB\u09C5\u09C6\u09C9\u09CA\u09CF-\u09D6\u09D8-\u09DB\u09DE\u09E4\u09E5\u09FC-\u0A00\u0A04\u0A0B-\u0A0E\u0A11\u0A12\u0A29\u0A31\u0A34\u0A37\u0A3A\u0A3B\u0A3D\u0A43-\u0A46\u0A49\u0A4A\u0A4E-\u0A50\u0A52-\u0A58\u0A5D\u0A5F-\u0A65\u0A76-\u0A80\u0A84\u0A8E\u0A92\u0AA9\u0AB1\u0AB4\u0ABA\u0ABB\u0AC6\u0ACA\u0ACE\u0ACF\u0AD1-\u0ADF\u0AE4\u0AE5\u0AF2-\u0B00\u0B04\u0B0D\u0B0E\u0B11\u0B12\u0B29\u0B31\u0B34\u0B3A\u0B3B\u0B45\u0B46\u0B49\u0B4A\u0B4E-\u0B55\u0B58-\u0B5B\u0B5E\u0B64\u0B65\u0B78-\u0B81\u0B84\u0B8B-\u0B8D\u0B91\u0B96-\u0B98\u0B9B\u0B9D\u0BA0-\u0BA2\u0BA5-\u0BA7\u0BAB-\u0BAD\u0BBA-\u0BBD\u0BC3-\u0BC5\u0BC9\u0BCE\u0BCF\u0BD1-\u0BD6\u0BD8-\u0BE5\u0BFB-\u0C00\u0C04\u0C0D\u0C11\u0C29\u0C34\u0C3A-\u0C3C\u0C45\u0C49\u0C4E-\u0C54\u0C57\u0C5A-\u0C5F\u0C64\u0C65\u0C70-\u0C77\u0C80\u0C81\u0C84\u0C8D\u0C91\u0CA9\u0CB4\u0CBA\u0CBB\u0CC5\u0CC9\u0CCE-\u0CD4\u0CD7-\u0CDD\u0CDF\u0CE4\u0CE5\u0CF0\u0CF3-\u0D01\u0D04\u0D0D\u0D11\u0D3B\u0D3C\u0D45\u0D49\u0D4F-\u0D56\u0D58-\u0D5F\u0D64\u0D65\u0D76-\u0D78\u0D80\u0D81\u0D84\u0D97-\u0D99\u0DB2\u0DBC\u0DBE\u0DBF\u0DC7-\u0DC9\u0DCB-\u0DCE\u0DD5\u0DD7\u0DE0-\u0DF1\u0DF5-\u0E00\u0E3B-\u0E3E\u0E5C-\u0E80\u0E83\u0E85\u0E86\u0E89\u0E8B\u0E8C\u0E8E-\u0E93\u0E98\u0EA0\u0EA4\u0EA6\u0EA8\u0EA9\u0EAC\u0EBA\u0EBE\u0EBF\u0EC5\u0EC7\u0ECE\u0ECF\u0EDA\u0EDB\u0EE0-\u0EFF\u0F48\u0F6D-\u0F70\u0F98\u0FBD\u0FCD\u0FDB-\u0FFF\u10C6\u10C8-\u10CC\u10CE\u10CF\u1249\u124E\u124F\u1257\u1259\u125E\u125F\u1289\u128E\u128F\u12B1\u12B6\u12B7\u12BF\u12C1\u12C6\u12C7\u12D7\u1311\u1316\u1317\u135B\u135C\u137D-\u137F\u139A-\u139F\u13F5-\u13FF\u169D-\u169F\u16F1-\u16FF\u170D\u1715-\u171F\u1737-\u173F\u1754-\u175F\u176D\u1771\u1774-\u177F\u17DE\u17DF\u17EA-\u17EF\u17FA-\u17FF\u180F\u181A-\u181F\u1878-\u187F\u18AB-\u18AF\u18F6-\u18FF\u191D-\u191F\u192C-\u192F\u193C-\u193F\u1941-\u1943\u196E\u196F\u1975-\u197F\u19AC-\u19AF\u19CA-\u19CF\u19DB-\u19DD\u1A1C\u1A1D\u1A5F\u1A7D\u1A7E\u1A8A-\u1A8F\u1A9A-\u1A9F\u1AAE-\u1AFF\u1B4C-\u1B4F\u1B7D-\u1B7F\u1BF4-\u1BFB\u1C38-\u1C3A\u1C4A-\u1C4C\u1C80-\u1CBF\u1CC8-\u1CCF\u1CF7-\u1CFF\u1DE7-\u1DFB\u1F16\u1F17\u1F1E\u1F1F\u1F46\u1F47\u1F4E\u1F4F\u1F58\u1F5A\u1F5C\u1F5E\u1F7E\u1F7F\u1FB5\u1FC5\u1FD4\u1FD5\u1FDC\u1FF0\u1FF1\u1FF5\u1FFF\u200B-\u200F\u202A-\u202E\u2060-\u206F\u2072\u2073\u208F\u209D-\u209F\u20BA-\u20CF\u20F1-\u20FF\u218A-\u218F\u23F4-\u23FF\u2427-\u243F\u244B-\u245F\u2700\u2B4D-\u2B4F\u2B5A-\u2BFF\u2C2F\u2C5F\u2CF4-\u2CF8\u2D26\u2D28-\u2D2C\u2D2E\u2D2F\u2D68-\u2D6E\u2D71-\u2D7E\u2D97-\u2D9F\u2DA7\u2DAF\u2DB7\u2DBF\u2DC7\u2DCF\u2DD7\u2DDF\u2E3C-\u2E7F\u2E9A\u2EF4-\u2EFF\u2FD6-\u2FEF\u2FFC-\u2FFF\u3040\u3097\u3098\u3100-\u3104\u312E-\u3130\u318F\u31BB-\u31BF\u31E4-\u31EF\u321F\u32FF\u4DB6-\u4DBF\u9FCD-\u9FFF\uA48D-\uA48F\uA4C7-\uA4CF\uA62C-\uA63F\uA698-\uA69E\uA6F8-\uA6FF\uA78F\uA794-\uA79F\uA7AB-\uA7F7\uA82C-\uA82F\uA83A-\uA83F\uA878-\uA87F\uA8C5-\uA8CD\uA8DA-\uA8DF\uA8FC-\uA8FF\uA954-\uA95E\uA97D-\uA97F\uA9CE\uA9DA-\uA9DD\uA9E0-\uA9FF\uAA37-\uAA3F\uAA4E\uAA4F\uAA5A\uAA5B\uAA7C-\uAA7F\uAAC3-\uAADA\uAAF7-\uAB00\uAB07\uAB08\uAB0F\uAB10\uAB17-\uAB1F\uAB27\uAB2F-\uABBF\uABEE\uABEF\uABFA-\uABFF\uD7A4-\uD7AF\uD7C7-\uD7CA\uD7FC-\uF8FF\uFA6E\uFA6F\uFADA-\uFAFF\uFB07-\uFB12\uFB18-\uFB1C\uFB37\uFB3D\uFB3F\uFB42\uFB45\uFBC2-\uFBD2\uFD40-\uFD4F\uFD90\uFD91\uFDC8-\uFDEF\uFDFE\uFDFF\uFE1A-\uFE1F\uFE27-\uFE2F\uFE53\uFE67\uFE6C-\uFE6F\uFE75\uFEFD-\uFF00\uFFBF-\uFFC1\uFFC8\uFFC9\uFFD0\uFFD1\uFFD8\uFFD9\uFFDD-\uFFDF\uFFE7\uFFEF-\uFFFB\uFFFE\uFFFF])/g;
+
+var utils = module.exports = {
+    objectIs: Object.is || function (a, b) {
+        // Polyfill from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+        if (a === 0 && b === 0) {
+            return 1 / a === 1 / b;
+        }
+        if (a !== a) {
+            return b !== b;
+        }
+        return a === b;
+    },
+
+    isArray: function (ar) {
+        return Object.prototype.toString.call(ar) === '[object Array]';
+    },
+
+    isRegExp: function (re) {
+        return (Object.prototype.toString.call(re) === '[object RegExp]');
+    },
+
+    isError: function (err) {
+        return typeof err === 'object' && (Object.prototype.toString.call(err) === '[object Error]' || err instanceof Error);
+    },
+
+    extend: function (target) {
+        for (var i = 1; i < arguments.length; i += 1) {
+            var source = arguments[i];
+            Object.keys(source).forEach(function (key) {
+                target[key] = source[key];
+            });
+        }
+        return target;
+    },
+
+    findFirst: function (arr, predicate, thisObj) {
+        var scope = thisObj || null;
+        for (var i = 0 ; i < arr.length ; i += 1) {
+            if (predicate.call(scope, arr[i], i, arr)) {
+                return arr[i];
+            }
+        }
+        return null;
+    },
+
+    leftPad: function (str, width, ch) {
+        ch = ch || ' ';
+        while (str.length < width) {
+            str = ch + str;
+        }
+        return str;
+    },
+
+    escapeRegExpMetaChars: function (str) {
+        return str.replace(/[[\]{}()*+?.\\^$|]/g, '\\$&');
+    },
+
+    escapeChar: function (ch) {
+        if (ch === '\t') {
+            return '\\t';
+        } else if (ch === '\r') {
+            return '\\r';
+        } else {
+            var charCode = ch.charCodeAt(0);
+            var hexChars = charCode.toString(16).toUpperCase();
+            if (charCode < 256) {
+                return '\\x' + utils.leftPad(hexChars, 2, '0');
+            } else {
+                return '\\u' + utils.leftPad(hexChars, 4, '0');
+            }
+        }
+    },
+
+    diffStrings: function (actual, expected, output, options) {
+        options = options || {};
+        var type = options.type || 'WordsWithSpace';
+
+        function addStringToOutput(output, text, baseStyle, specialCharStyle) {
+            if (options.markUpSpecialCharacters) {
+                text.split(specialCharRegexp).forEach(function (part) {
+                    if (specialCharRegexp.test(part)) {
+                        output[specialCharStyle || baseStyle](utils.escapeChar(part));
+                    } else {
+                        output[baseStyle](part);
+                    }
+                });
+            } else {
+                output[baseStyle](text);
+            }
+            return output;
+        }
+
+        var diffLines = [];
+        var lastPart;
+        stringDiff.diffLines(actual, expected).forEach(function (part) {
+            if (lastPart && lastPart.added && part.removed) {
+                diffLines.push({
+                    oldValue: part.value,
+                    newValue: lastPart.value,
+                    replaced: true
+                });
+                lastPart = null;
+            } else if (lastPart) {
+                diffLines.push(lastPart);
+                lastPart = part;
+            } else {
+                lastPart = part;
+            }
+        });
+        if (lastPart) {
+            diffLines.push(lastPart);
+        }
+
+        diffLines.forEach(function (part, index) {
+            var endsWithNewline = /\n$/.test(part.value);
+            var value;
+            if (part.replaced) {
+                var oldLine = output.clone();
+                var newLine = output.clone();
+                var oldValue = part.oldValue;
+                var newValue = part.newValue;
+                var oldEndsWithNewline = oldValue.slice(-1) === '\n';
+                var newEndsWithNewline = newValue.slice(-1) === '\n';
+                if (oldEndsWithNewline) {
+                    oldValue = oldValue.slice(0, -1);
+                }
+                if (newEndsWithNewline) {
+                    newValue = newValue.slice(0, -1);
+                }
+
+                stringDiff['diff' + type](oldValue, newValue).forEach(function (part) {
+                    if (part.added) {
+                        addStringToOutput(newLine, part.value, 'diffAddedHighlight', 'diffAddedSpecialChar');
+                    } else if (part.removed) {
+                        addStringToOutput(oldLine, part.value, 'diffRemovedHighlight', 'diffRemovedSpecialChar');
+                    } else {
+                        newLine.diffAddedLine(part.value);
+                        oldLine.diffRemovedLine(part.value);
+                    }
+                });
+                oldLine.prependLinesWith(output.clone().diffRemovedLine('-'));
+                newLine.prependLinesWith(output.clone().diffAddedLine('+'));
+
+                if (oldEndsWithNewline && !newEndsWithNewline) {
+                    oldLine.diffRemovedSpecialChar('\\n');
+                }
+
+                if (newEndsWithNewline && !oldEndsWithNewline) {
+                    newLine.diffAddedSpecialChar('\\n');
+                }
+
+                output.append(oldLine).nl().append(newLine);
+                if (oldEndsWithNewline && index < diffLines.length - 1) {
+                    output.nl();
+                }
+            } else if (part.added) {
+                value = endsWithNewline ?
+                    part.value.slice(0, -1) :
+                    part.value;
+
+                output.append(function () {
+                    addStringToOutput(this, value, 'diffAddedLine').prependLinesWith(function () {
+                        this.diffAddedLine('+');
+                    });
+                });
+
+                if (endsWithNewline) {
+                    output.nl();
+                }
+            } else if (part.removed) {
+                value = endsWithNewline ?
+                    part.value.slice(0, -1) :
+                    part.value;
+
+                output.append(function () {
+                    addStringToOutput(this, value, 'diffRemovedLine').prependLinesWith(function () {
+                        this.diffRemovedLine('-');
+                    });
+                });
+
+                if (endsWithNewline) {
+                    output.nl();
+                }
+            } else {
+                output.text(part.value.replace(/^(.)/gm, ' $1'));
+            }
+        });
+        return output;
+    },
+
+    getFunctionName: function (f) {
+        if (typeof f.name === 'string') {
+            return f.name;
+        }
+        var matchFunctionName = Function.prototype.toString.call(f).match(/function ([^\(]+)/);
+        if (matchFunctionName) {
+            return matchFunctionName[1];
+        }
+
+        if (f === Object) {
+            return 'Object';
+        }
+        if (f === Function) {
+            return 'Function';
+        }
+    },
+
+    wrapConstructorNameAroundOutput: function (output, obj) {
+        var constructor = obj.constructor;
+        var constructorName = constructor && constructor !== Object && utils.getFunctionName(constructor);
+        if (constructorName && constructorName !== 'Object') {
+            return output.clone().text(constructorName + '(').append(output).text(')');
+        } else {
+            return output;
+        }
+    }
+};
+
+},{}],14:[function(require,module,exports){
+/*global Promise:true*/
+var Promise = require(18);
+
+var workQueue = {
+    queue: [],
+    drain: function () {
+        this.queue.forEach(function (fn) {
+            fn();
+        });
+        this.queue = [];
+    }
+};
+
+var scheduler = Promise.setScheduler(function (fn) {
+    workQueue.queue.push(fn);
+    scheduler(function () {
+        workQueue.drain();
+    });
+});
+
+
+Promise.prototype._notifyUnhandledRejection = function () {
+    var that = this;
+    scheduler(function () {
+        if (that._isRejectionUnhandled()) {
+            if (workQueue.onUnhandledRejection) { // for testing
+                workQueue.onUnhandledRejection(that.reason());
+            } else {
+                throw that.reason();
+            }
+        }
+    });
+};
+
+module.exports = workQueue;
+
+},{}],15:[function(require,module,exports){
+module.exports = require(2).create()
+    .use(require(9))
+    .use(require(12))
+    .use(require(4));
+
+// Add an inspect method to all the promises we return that will make the REPL, console.log, and util.inspect render it nicely in node.js:
+require(18).prototype.inspect = function () {
+    return module.exports.createOutput(require(29).defaultFormat).appendInspected(this).toString();
+};
+
+},{}],16:[function(require,module,exports){
+var arrayDiff = require(17);
+
+function extend(target) {
+    for (var i = 1; i < arguments.length; i += 1) {
+        var source = arguments[i];
+        Object.keys(source).forEach(function (key) {
+            target[key] = source[key];
+        });
+    }
+    return target;
+}
+
+module.exports = function arrayChanges(actual, expected, equal, similar) {
+    var mutatedArray = new Array(actual.length);
+
+    for (var k = 0; k < actual.length; k += 1) {
+        mutatedArray[k] = {
+            type: 'similar',
+            value: actual[k]
+        };
+    }
+
+    if (mutatedArray.length > 0) {
+        mutatedArray[mutatedArray.length - 1].last = true;
+    }
+
+    similar = similar || function (a, b) {
+        return false;
+    };
+
+    var itemsDiff = arrayDiff([].concat(actual), [].concat(expected), function (a, b) {
+        return equal(a, b) || similar(a, b);
+    });
+
+    var removeTable = [];
+    function offsetIndex(index) {
+        return index + (removeTable[index - 1] || 0);
+    }
+
+    var removes = itemsDiff.filter(function (diffItem) {
+        return diffItem.type === 'remove';
+    });
+
+    var removesByIndex = {};
+    var removedItems = 0;
+    removes.forEach(function (diffItem) {
+        var removeIndex = removedItems + diffItem.index;
+        mutatedArray.slice(removeIndex, diffItem.howMany + removeIndex).forEach(function (v) {
+            v.type = 'remove';
+        });
+        removedItems += diffItem.howMany;
+        removesByIndex[diffItem.index] = removedItems;
+    });
+
+    function updateRemoveTable() {
+        removedItems = 0;
+        Array.prototype.forEach.call(actual, function (_, index) {
+            removedItems += removesByIndex[index] || 0;
+            removeTable[index] = removedItems;
+        });
+    }
+
+    updateRemoveTable();
+
+    var moves = itemsDiff.filter(function (diffItem) {
+        return diffItem.type === 'move';
+    });
+
+    var movedItems = 0;
+    moves.forEach(function (diffItem) {
+        var moveFromIndex = offsetIndex(diffItem.from);
+        var removed = mutatedArray.slice(moveFromIndex, diffItem.howMany + moveFromIndex);
+        var added = removed.map(function (v) {
+            return extend({}, v, { last: false, type: 'insert' });
+        });
+        removed.forEach(function (v) {
+            v.type = 'remove';
+        });
+        Array.prototype.splice.apply(mutatedArray, [offsetIndex(diffItem.to), 0].concat(added));
+        movedItems += diffItem.howMany;
+        removesByIndex[diffItem.from] = movedItems;
+        updateRemoveTable();
+    });
+
+    var inserts = itemsDiff.filter(function (diffItem) {
+        return diffItem.type === 'insert';
+    });
+
+    inserts.forEach(function (diffItem) {
+        var added = new Array(diffItem.values.length);
+        for (var i = 0 ; i < diffItem.values.length ; i += 1) {
+            added[i] = {
+                type: 'insert',
+                value: diffItem.values[i]
+            };
+        }
+        Array.prototype.splice.apply(mutatedArray, [offsetIndex(diffItem.index), 0].concat(added));
+    });
+
+    var offset = 0;
+    mutatedArray.forEach(function (diffItem, index) {
+        var type = diffItem.type;
+        if (type === 'remove') {
+            offset -= 1;
+        } else if (type === 'similar') {
+            diffItem.expected = expected[offset + index];
+        }
+    });
+
+    var conflicts = mutatedArray.reduce(function (conflicts, item) {
+        return item.type === 'similar' ? conflicts : conflicts + 1;
+    }, 0);
+
+    for (var i = 0, c = 0; i < Math.max(actual.length, expected.length) &&  c <= conflicts; i += 1) {
+        var expectedType = typeof expected[i];
+        var actualType = typeof actual[i];
+
+        if (
+            actualType !== expectedType ||
+                ((actualType === 'object' || actualType === 'string') && !similar(actual[i], expected[i])) ||
+                (actualType !== 'object' && actualType !== 'string' && !equal(actual[i], expected[i]))
+        ) {
+            c += 1;
+        }
+    }
+
+    if (c <= conflicts) {
+        mutatedArray = [];
+        var j;
+        for (j = 0; j < Math.min(actual.length, expected.length); j += 1) {
+            mutatedArray.push({
+                type: 'similar',
+                value: actual[j],
+                expected: expected[j]
+            });
+        }
+
+        if (actual.length < expected.length) {
+            for (; j < Math.max(actual.length, expected.length); j += 1) {
+                mutatedArray.push({
+                    type: 'insert',
+                    value: expected[j]
+                });
+            }
+        } else {
+            for (; j < Math.max(actual.length, expected.length); j += 1) {
+                mutatedArray.push({
+                    type: 'remove',
+                    value: actual[j]
+                });
+            }
+        }
+        if (mutatedArray.length > 0) {
+            mutatedArray[mutatedArray.length - 1].last = true;
+        }
+    }
+
+    mutatedArray.forEach(function (diffItem) {
+        if (diffItem.type === 'similar' && equal(diffItem.value, diffItem.expected)) {
+            diffItem.type = 'equal';
+        }
+    });
+
+    return mutatedArray;
+};
+
+},{}],17:[function(require,module,exports){
+module.exports = arrayDiff;
+
+// Based on some rough benchmarking, this algorithm is about O(2n) worst case,
+// and it can compute diffs on random arrays of length 1024 in about 34ms,
+// though just a few changes on an array of length 1024 takes about 0.5ms
+
+arrayDiff.InsertDiff = InsertDiff;
+arrayDiff.RemoveDiff = RemoveDiff;
+arrayDiff.MoveDiff = MoveDiff;
+
+function InsertDiff(index, values) {
+  this.index = index;
+  this.values = values;
+}
+InsertDiff.prototype.type = 'insert';
+InsertDiff.prototype.toJSON = function() {
+  return {
+    type: this.type
+  , index: this.index
+  , values: this.values
+  };
+};
+
+function RemoveDiff(index, howMany) {
+  this.index = index;
+  this.howMany = howMany;
+}
+RemoveDiff.prototype.type = 'remove';
+RemoveDiff.prototype.toJSON = function() {
+  return {
+    type: this.type
+  , index: this.index
+  , howMany: this.howMany
+  };
+};
+
+function MoveDiff(from, to, howMany) {
+  this.from = from;
+  this.to = to;
+  this.howMany = howMany;
+}
+MoveDiff.prototype.type = 'move';
+MoveDiff.prototype.toJSON = function() {
+  return {
+    type: this.type
+  , from: this.from
+  , to: this.to
+  , howMany: this.howMany
+  };
+};
+
+function strictEqual(a, b) {
+  return a === b;
+}
+
+function arrayDiff(before, after, equalFn) {
+  if (!equalFn) equalFn = strictEqual;
+
+  // Find all items in both the before and after array, and represent them
+  // as moves. Many of these "moves" may end up being discarded in the last
+  // pass if they are from an index to the same index, but we don't know this
+  // up front, since we haven't yet offset the indices.
+  // 
+  // Also keep a map of all the indicies accounted for in the before and after
+  // arrays. These maps are used next to create insert and remove diffs.
+  var beforeLength = before.length;
+  var afterLength = after.length;
+  var moves = [];
+  var beforeMarked = {};
+  var afterMarked = {};
+  for (var beforeIndex = 0; beforeIndex < beforeLength; beforeIndex++) {
+    var beforeItem = before[beforeIndex];
+    for (var afterIndex = 0; afterIndex < afterLength; afterIndex++) {
+      if (afterMarked[afterIndex]) continue;
+      if (!equalFn(beforeItem, after[afterIndex])) continue;
+      var from = beforeIndex;
+      var to = afterIndex;
+      var howMany = 0;
+      do {
+        beforeMarked[beforeIndex++] = afterMarked[afterIndex++] = true;
+        howMany++;
+      } while (
+        beforeIndex < beforeLength &&
+        afterIndex < afterLength &&
+        equalFn(before[beforeIndex], after[afterIndex]) &&
+        !afterMarked[afterIndex]
+      );
+      moves.push(new MoveDiff(from, to, howMany));
+      beforeIndex--;
+      break;
+    }
+  }
+
+  // Create a remove for all of the items in the before array that were
+  // not marked as being matched in the after array as well
+  var removes = [];
+  for (beforeIndex = 0; beforeIndex < beforeLength;) {
+    if (beforeMarked[beforeIndex]) {
+      beforeIndex++;
+      continue;
+    }
+    var index = beforeIndex;
+    var howMany = 0;
+    while (beforeIndex < beforeLength && !beforeMarked[beforeIndex++]) {
+      howMany++;
+    }
+    removes.push(new RemoveDiff(index, howMany));
+  }
+
+  // Create an insert for all of the items in the after array that were
+  // not marked as being matched in the before array as well
+  var inserts = [];
+  for (afterIndex = 0; afterIndex < afterLength;) {
+    if (afterMarked[afterIndex]) {
+      afterIndex++;
+      continue;
+    }
+    var index = afterIndex;
+    var howMany = 0;
+    while (afterIndex < afterLength && !afterMarked[afterIndex++]) {
+      howMany++;
+    }
+    var values = after.slice(index, index + howMany);
+    inserts.push(new InsertDiff(index, values));
+  }
+
+  var insertsLength = inserts.length;
+  var removesLength = removes.length;
+  var movesLength = moves.length;
+  var i, j;
+
+  // Offset subsequent removes and moves by removes
+  var count = 0;
+  for (i = 0; i < removesLength; i++) {
+    var remove = removes[i];
+    remove.index -= count;
+    count += remove.howMany;
+    for (j = 0; j < movesLength; j++) {
+      var move = moves[j];
+      if (move.from >= remove.index) move.from -= remove.howMany;
+    }
+  }
+
+  // Offset moves by inserts
+  for (i = insertsLength; i--;) {
+    var insert = inserts[i];
+    var howMany = insert.values.length;
+    for (j = movesLength; j--;) {
+      var move = moves[j];
+      if (move.to >= insert.index) move.to -= howMany;
+    }
+  }
+
+  // Offset the to of moves by later moves
+  for (i = movesLength; i-- > 1;) {
+    var move = moves[i];
+    if (move.to === move.from) continue;
+    for (j = i; j--;) {
+      var earlier = moves[j];
+      if (earlier.to >= move.to) earlier.to -= move.howMany;
+      if (earlier.to >= move.from) earlier.to += move.howMany;
+    }
+  }
+
+  // Only output moves that end up having an effect after offsetting
+  var outputMoves = [];
+
+  // Offset the from of moves by earlier moves
+  for (i = 0; i < movesLength; i++) {
+    var move = moves[i];
+    if (move.to === move.from) continue;
+    outputMoves.push(move);
+    for (j = i + 1; j < movesLength; j++) {
+      var later = moves[j];
+      if (later.from >= move.from) later.from -= move.howMany;
+      if (later.from >= move.to) later.from += move.howMany;
+    }
+  }
+
+  return removes.concat(outputMoves, inserts);
+}
+
+},{}],18:[function(require,module,exports){
+(function (process,global){
+/* @preserve
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2014 Petka Antonov
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * 
+ */
+/**
+ * bluebird build version 2.9.34
+ * Features enabled: core, race, call_get, generators, map, nodeify, promisify, props, reduce, settle, some, cancel, using, filter, any, each, timers
+*/
+!function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.Promise=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof _dereq_=="function"&&_dereq_;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof _dereq_=="function"&&_dereq_;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(_dereq_,module,exports){
+"use strict";
+module.exports = function(Promise) {
+var SomePromiseArray = Promise._SomePromiseArray;
+function any(promises) {
+    var ret = new SomePromiseArray(promises);
+    var promise = ret.promise();
+    ret.setHowMany(1);
+    ret.setUnwrap();
+    ret.init();
+    return promise;
+}
+
+Promise.any = function (promises) {
+    return any(promises);
+};
+
+Promise.prototype.any = function () {
+    return any(this);
+};
+
+};
+
+},{}],2:[function(_dereq_,module,exports){
+"use strict";
+var firstLineError;
+try {throw new Error(); } catch (e) {firstLineError = e;}
+var schedule = _dereq_("./schedule.js");
+var Queue = _dereq_("./queue.js");
+var util = _dereq_("./util.js");
+
+function Async() {
+    this._isTickUsed = false;
+    this._lateQueue = new Queue(16);
+    this._normalQueue = new Queue(16);
+    this._trampolineEnabled = true;
+    var self = this;
+    this.drainQueues = function () {
+        self._drainQueues();
+    };
+    this._schedule =
+        schedule.isStatic ? schedule(this.drainQueues) : schedule;
+}
+
+Async.prototype.disableTrampolineIfNecessary = function() {
+    if (util.hasDevTools) {
+        this._trampolineEnabled = false;
+    }
+};
+
+Async.prototype.enableTrampoline = function() {
+    if (!this._trampolineEnabled) {
+        this._trampolineEnabled = true;
+        this._schedule = function(fn) {
+            setTimeout(fn, 0);
+        };
+    }
+};
+
+Async.prototype.haveItemsQueued = function () {
+    return this._normalQueue.length() > 0;
+};
+
+Async.prototype.throwLater = function(fn, arg) {
+    if (arguments.length === 1) {
+        arg = fn;
+        fn = function () { throw arg; };
+    }
+    if (typeof setTimeout !== "undefined") {
+        setTimeout(function() {
+            fn(arg);
+        }, 0);
+    } else try {
+        this._schedule(function() {
+            fn(arg);
+        });
+    } catch (e) {
+        throw new Error("No async scheduler available\u000a\u000a    See http://goo.gl/m3OTXk\u000a");
+    }
+};
+
+function AsyncInvokeLater(fn, receiver, arg) {
+    this._lateQueue.push(fn, receiver, arg);
+    this._queueTick();
+}
+
+function AsyncInvoke(fn, receiver, arg) {
+    this._normalQueue.push(fn, receiver, arg);
+    this._queueTick();
+}
+
+function AsyncSettlePromises(promise) {
+    this._normalQueue._pushOne(promise);
+    this._queueTick();
+}
+
+if (!util.hasDevTools) {
+    Async.prototype.invokeLater = AsyncInvokeLater;
+    Async.prototype.invoke = AsyncInvoke;
+    Async.prototype.settlePromises = AsyncSettlePromises;
+} else {
+    if (schedule.isStatic) {
+        schedule = function(fn) { setTimeout(fn, 0); };
+    }
+    Async.prototype.invokeLater = function (fn, receiver, arg) {
+        if (this._trampolineEnabled) {
+            AsyncInvokeLater.call(this, fn, receiver, arg);
+        } else {
+            this._schedule(function() {
+                setTimeout(function() {
+                    fn.call(receiver, arg);
+                }, 100);
+            });
+        }
+    };
+
+    Async.prototype.invoke = function (fn, receiver, arg) {
+        if (this._trampolineEnabled) {
+            AsyncInvoke.call(this, fn, receiver, arg);
+        } else {
+            this._schedule(function() {
+                fn.call(receiver, arg);
+            });
+        }
+    };
+
+    Async.prototype.settlePromises = function(promise) {
+        if (this._trampolineEnabled) {
+            AsyncSettlePromises.call(this, promise);
+        } else {
+            this._schedule(function() {
+                promise._settlePromises();
+            });
+        }
+    };
+}
+
+Async.prototype.invokeFirst = function (fn, receiver, arg) {
+    this._normalQueue.unshift(fn, receiver, arg);
+    this._queueTick();
+};
+
+Async.prototype._drainQueue = function(queue) {
+    while (queue.length() > 0) {
+        var fn = queue.shift();
+        if (typeof fn !== "function") {
+            fn._settlePromises();
+            continue;
+        }
+        var receiver = queue.shift();
+        var arg = queue.shift();
+        fn.call(receiver, arg);
+    }
+};
+
+Async.prototype._drainQueues = function () {
+    this._drainQueue(this._normalQueue);
+    this._reset();
+    this._drainQueue(this._lateQueue);
+};
+
+Async.prototype._queueTick = function () {
+    if (!this._isTickUsed) {
+        this._isTickUsed = true;
+        this._schedule(this.drainQueues);
+    }
+};
+
+Async.prototype._reset = function () {
+    this._isTickUsed = false;
+};
+
+module.exports = new Async();
+module.exports.firstLineError = firstLineError;
+
+},{"./queue.js":28,"./schedule.js":31,"./util.js":38}],3:[function(_dereq_,module,exports){
+"use strict";
+module.exports = function(Promise, INTERNAL, tryConvertToPromise) {
+var rejectThis = function(_, e) {
+    this._reject(e);
+};
+
+var targetRejected = function(e, context) {
+    context.promiseRejectionQueued = true;
+    context.bindingPromise._then(rejectThis, rejectThis, null, this, e);
+};
+
+var bindingResolved = function(thisArg, context) {
+    if (this._isPending()) {
+        this._resolveCallback(context.target);
+    }
+};
+
+var bindingRejected = function(e, context) {
+    if (!context.promiseRejectionQueued) this._reject(e);
+};
+
+Promise.prototype.bind = function (thisArg) {
+    var maybePromise = tryConvertToPromise(thisArg);
+    var ret = new Promise(INTERNAL);
+    ret._propagateFrom(this, 1);
+    var target = this._target();
+
+    ret._setBoundTo(maybePromise);
+    if (maybePromise instanceof Promise) {
+        var context = {
+            promiseRejectionQueued: false,
+            promise: ret,
+            target: target,
+            bindingPromise: maybePromise
+        };
+        target._then(INTERNAL, targetRejected, ret._progress, ret, context);
+        maybePromise._then(
+            bindingResolved, bindingRejected, ret._progress, ret, context);
+    } else {
+        ret._resolveCallback(target);
+    }
+    return ret;
+};
+
+Promise.prototype._setBoundTo = function (obj) {
+    if (obj !== undefined) {
+        this._bitField = this._bitField | 131072;
+        this._boundTo = obj;
+    } else {
+        this._bitField = this._bitField & (~131072);
+    }
+};
+
+Promise.prototype._isBound = function () {
+    return (this._bitField & 131072) === 131072;
+};
+
+Promise.bind = function (thisArg, value) {
+    var maybePromise = tryConvertToPromise(thisArg);
+    var ret = new Promise(INTERNAL);
+
+    ret._setBoundTo(maybePromise);
+    if (maybePromise instanceof Promise) {
+        maybePromise._then(function() {
+            ret._resolveCallback(value);
+        }, ret._reject, ret._progress, ret, null);
+    } else {
+        ret._resolveCallback(value);
+    }
+    return ret;
+};
+};
+
+},{}],4:[function(_dereq_,module,exports){
+"use strict";
+var old;
+if (typeof Promise !== "undefined") old = Promise;
+function noConflict() {
+    try { if (Promise === bluebird) Promise = old; }
+    catch (e) {}
+    return bluebird;
+}
+var bluebird = _dereq_("./promise.js")();
+bluebird.noConflict = noConflict;
+module.exports = bluebird;
+
+},{"./promise.js":23}],5:[function(_dereq_,module,exports){
+"use strict";
+var cr = Object.create;
+if (cr) {
+    var callerCache = cr(null);
+    var getterCache = cr(null);
+    callerCache[" size"] = getterCache[" size"] = 0;
+}
+
+module.exports = function(Promise) {
+var util = _dereq_("./util.js");
+var canEvaluate = util.canEvaluate;
+var isIdentifier = util.isIdentifier;
+
+var getMethodCaller;
+var getGetter;
+if (!true) {
+var makeMethodCaller = function (methodName) {
+    return new Function("ensureMethod", "                                    \n\
+        return function(obj) {                                               \n\
+            'use strict'                                                     \n\
+            var len = this.length;                                           \n\
+            ensureMethod(obj, 'methodName');                                 \n\
+            switch(len) {                                                    \n\
+                case 1: return obj.methodName(this[0]);                      \n\
+                case 2: return obj.methodName(this[0], this[1]);             \n\
+                case 3: return obj.methodName(this[0], this[1], this[2]);    \n\
+                case 0: return obj.methodName();                             \n\
+                default:                                                     \n\
+                    return obj.methodName.apply(obj, this);                  \n\
+            }                                                                \n\
+        };                                                                   \n\
+        ".replace(/methodName/g, methodName))(ensureMethod);
+};
+
+var makeGetter = function (propertyName) {
+    return new Function("obj", "                                             \n\
+        'use strict';                                                        \n\
+        return obj.propertyName;                                             \n\
+        ".replace("propertyName", propertyName));
+};
+
+var getCompiled = function(name, compiler, cache) {
+    var ret = cache[name];
+    if (typeof ret !== "function") {
+        if (!isIdentifier(name)) {
+            return null;
+        }
+        ret = compiler(name);
+        cache[name] = ret;
+        cache[" size"]++;
+        if (cache[" size"] > 512) {
+            var keys = Object.keys(cache);
+            for (var i = 0; i < 256; ++i) delete cache[keys[i]];
+            cache[" size"] = keys.length - 256;
+        }
+    }
+    return ret;
+};
+
+getMethodCaller = function(name) {
+    return getCompiled(name, makeMethodCaller, callerCache);
+};
+
+getGetter = function(name) {
+    return getCompiled(name, makeGetter, getterCache);
+};
+}
+
+function ensureMethod(obj, methodName) {
+    var fn;
+    if (obj != null) fn = obj[methodName];
+    if (typeof fn !== "function") {
+        var message = "Object " + util.classString(obj) + " has no method '" +
+            util.toString(methodName) + "'";
+        throw new Promise.TypeError(message);
+    }
+    return fn;
+}
+
+function caller(obj) {
+    var methodName = this.pop();
+    var fn = ensureMethod(obj, methodName);
+    return fn.apply(obj, this);
+}
+Promise.prototype.call = function (methodName) {
+    var $_len = arguments.length;var args = new Array($_len - 1); for(var $_i = 1; $_i < $_len; ++$_i) {args[$_i - 1] = arguments[$_i];}
+    if (!true) {
+        if (canEvaluate) {
+            var maybeCaller = getMethodCaller(methodName);
+            if (maybeCaller !== null) {
+                return this._then(
+                    maybeCaller, undefined, undefined, args, undefined);
+            }
+        }
+    }
+    args.push(methodName);
+    return this._then(caller, undefined, undefined, args, undefined);
+};
+
+function namedGetter(obj) {
+    return obj[this];
+}
+function indexedGetter(obj) {
+    var index = +this;
+    if (index < 0) index = Math.max(0, index + obj.length);
+    return obj[index];
+}
+Promise.prototype.get = function (propertyName) {
+    var isIndex = (typeof propertyName === "number");
+    var getter;
+    if (!isIndex) {
+        if (canEvaluate) {
+            var maybeGetter = getGetter(propertyName);
+            getter = maybeGetter !== null ? maybeGetter : namedGetter;
+        } else {
+            getter = namedGetter;
+        }
+    } else {
+        getter = indexedGetter;
+    }
+    return this._then(getter, undefined, undefined, propertyName, undefined);
+};
+};
+
+},{"./util.js":38}],6:[function(_dereq_,module,exports){
+"use strict";
+module.exports = function(Promise) {
+var errors = _dereq_("./errors.js");
+var async = _dereq_("./async.js");
+var CancellationError = errors.CancellationError;
+
+Promise.prototype._cancel = function (reason) {
+    if (!this.isCancellable()) return this;
+    var parent;
+    var promiseToReject = this;
+    while ((parent = promiseToReject._cancellationParent) !== undefined &&
+        parent.isCancellable()) {
+        promiseToReject = parent;
+    }
+    this._unsetCancellable();
+    promiseToReject._target()._rejectCallback(reason, false, true);
+};
+
+Promise.prototype.cancel = function (reason) {
+    if (!this.isCancellable()) return this;
+    if (reason === undefined) reason = new CancellationError();
+    async.invokeLater(this._cancel, this, reason);
+    return this;
+};
+
+Promise.prototype.cancellable = function () {
+    if (this._cancellable()) return this;
+    async.enableTrampoline();
+    this._setCancellable();
+    this._cancellationParent = undefined;
+    return this;
+};
+
+Promise.prototype.uncancellable = function () {
+    var ret = this.then();
+    ret._unsetCancellable();
+    return ret;
+};
+
+Promise.prototype.fork = function (didFulfill, didReject, didProgress) {
+    var ret = this._then(didFulfill, didReject, didProgress,
+                         undefined, undefined);
+
+    ret._setCancellable();
+    ret._cancellationParent = undefined;
+    return ret;
+};
+};
+
+},{"./async.js":2,"./errors.js":13}],7:[function(_dereq_,module,exports){
+"use strict";
+module.exports = function() {
+var async = _dereq_("./async.js");
+var util = _dereq_("./util.js");
+var bluebirdFramePattern =
+    /[\\\/]bluebird[\\\/]js[\\\/](main|debug|zalgo|instrumented)/;
+var stackFramePattern = null;
+var formatStack = null;
+var indentStackFrames = false;
+var warn;
+
+function CapturedTrace(parent) {
+    this._parent = parent;
+    var length = this._length = 1 + (parent === undefined ? 0 : parent._length);
+    captureStackTrace(this, CapturedTrace);
+    if (length > 32) this.uncycle();
+}
+util.inherits(CapturedTrace, Error);
+
+CapturedTrace.prototype.uncycle = function() {
+    var length = this._length;
+    if (length < 2) return;
+    var nodes = [];
+    var stackToIndex = {};
+
+    for (var i = 0, node = this; node !== undefined; ++i) {
+        nodes.push(node);
+        node = node._parent;
+    }
+    length = this._length = i;
+    for (var i = length - 1; i >= 0; --i) {
+        var stack = nodes[i].stack;
+        if (stackToIndex[stack] === undefined) {
+            stackToIndex[stack] = i;
+        }
+    }
+    for (var i = 0; i < length; ++i) {
+        var currentStack = nodes[i].stack;
+        var index = stackToIndex[currentStack];
+        if (index !== undefined && index !== i) {
+            if (index > 0) {
+                nodes[index - 1]._parent = undefined;
+                nodes[index - 1]._length = 1;
+            }
+            nodes[i]._parent = undefined;
+            nodes[i]._length = 1;
+            var cycleEdgeNode = i > 0 ? nodes[i - 1] : this;
+
+            if (index < length - 1) {
+                cycleEdgeNode._parent = nodes[index + 1];
+                cycleEdgeNode._parent.uncycle();
+                cycleEdgeNode._length =
+                    cycleEdgeNode._parent._length + 1;
+            } else {
+                cycleEdgeNode._parent = undefined;
+                cycleEdgeNode._length = 1;
+            }
+            var currentChildLength = cycleEdgeNode._length + 1;
+            for (var j = i - 2; j >= 0; --j) {
+                nodes[j]._length = currentChildLength;
+                currentChildLength++;
+            }
+            return;
+        }
+    }
+};
+
+CapturedTrace.prototype.parent = function() {
+    return this._parent;
+};
+
+CapturedTrace.prototype.hasParent = function() {
+    return this._parent !== undefined;
+};
+
+CapturedTrace.prototype.attachExtraTrace = function(error) {
+    if (error.__stackCleaned__) return;
+    this.uncycle();
+    var parsed = CapturedTrace.parseStackAndMessage(error);
+    var message = parsed.message;
+    var stacks = [parsed.stack];
+
+    var trace = this;
+    while (trace !== undefined) {
+        stacks.push(cleanStack(trace.stack.split("\n")));
+        trace = trace._parent;
+    }
+    removeCommonRoots(stacks);
+    removeDuplicateOrEmptyJumps(stacks);
+    util.notEnumerableProp(error, "stack", reconstructStack(message, stacks));
+    util.notEnumerableProp(error, "__stackCleaned__", true);
+};
+
+function reconstructStack(message, stacks) {
+    for (var i = 0; i < stacks.length - 1; ++i) {
+        stacks[i].push("From previous event:");
+        stacks[i] = stacks[i].join("\n");
+    }
+    if (i < stacks.length) {
+        stacks[i] = stacks[i].join("\n");
+    }
+    return message + "\n" + stacks.join("\n");
+}
+
+function removeDuplicateOrEmptyJumps(stacks) {
+    for (var i = 0; i < stacks.length; ++i) {
+        if (stacks[i].length === 0 ||
+            ((i + 1 < stacks.length) && stacks[i][0] === stacks[i+1][0])) {
+            stacks.splice(i, 1);
+            i--;
+        }
+    }
+}
+
+function removeCommonRoots(stacks) {
+    var current = stacks[0];
+    for (var i = 1; i < stacks.length; ++i) {
+        var prev = stacks[i];
+        var currentLastIndex = current.length - 1;
+        var currentLastLine = current[currentLastIndex];
+        var commonRootMeetPoint = -1;
+
+        for (var j = prev.length - 1; j >= 0; --j) {
+            if (prev[j] === currentLastLine) {
+                commonRootMeetPoint = j;
+                break;
+            }
+        }
+
+        for (var j = commonRootMeetPoint; j >= 0; --j) {
+            var line = prev[j];
+            if (current[currentLastIndex] === line) {
+                current.pop();
+                currentLastIndex--;
+            } else {
+                break;
+            }
+        }
+        current = prev;
+    }
+}
+
+function cleanStack(stack) {
+    var ret = [];
+    for (var i = 0; i < stack.length; ++i) {
+        var line = stack[i];
+        var isTraceLine = stackFramePattern.test(line) ||
+            "    (No stack trace)" === line;
+        var isInternalFrame = isTraceLine && shouldIgnore(line);
+        if (isTraceLine && !isInternalFrame) {
+            if (indentStackFrames && line.charAt(0) !== " ") {
+                line = "    " + line;
+            }
+            ret.push(line);
+        }
+    }
+    return ret;
+}
+
+function stackFramesAsArray(error) {
+    var stack = error.stack.replace(/\s+$/g, "").split("\n");
+    for (var i = 0; i < stack.length; ++i) {
+        var line = stack[i];
+        if ("    (No stack trace)" === line || stackFramePattern.test(line)) {
+            break;
+        }
+    }
+    if (i > 0) {
+        stack = stack.slice(i);
+    }
+    return stack;
+}
+
+CapturedTrace.parseStackAndMessage = function(error) {
+    var stack = error.stack;
+    var message = error.toString();
+    stack = typeof stack === "string" && stack.length > 0
+                ? stackFramesAsArray(error) : ["    (No stack trace)"];
+    return {
+        message: message,
+        stack: cleanStack(stack)
+    };
+};
+
+CapturedTrace.formatAndLogError = function(error, title) {
+    if (typeof console !== "undefined") {
+        var message;
+        if (typeof error === "object" || typeof error === "function") {
+            var stack = error.stack;
+            message = title + formatStack(stack, error);
+        } else {
+            message = title + String(error);
+        }
+        if (typeof warn === "function") {
+            warn(message);
+        } else if (typeof console.log === "function" ||
+            typeof console.log === "object") {
+            console.log(message);
+        }
+    }
+};
+
+CapturedTrace.unhandledRejection = function (reason) {
+    CapturedTrace.formatAndLogError(reason, "^--- With additional stack trace: ");
+};
+
+CapturedTrace.isSupported = function () {
+    return typeof captureStackTrace === "function";
+};
+
+CapturedTrace.fireRejectionEvent =
+function(name, localHandler, reason, promise) {
+    var localEventFired = false;
+    try {
+        if (typeof localHandler === "function") {
+            localEventFired = true;
+            if (name === "rejectionHandled") {
+                localHandler(promise);
+            } else {
+                localHandler(reason, promise);
+            }
+        }
+    } catch (e) {
+        async.throwLater(e);
+    }
+
+    var globalEventFired = false;
+    try {
+        globalEventFired = fireGlobalEvent(name, reason, promise);
+    } catch (e) {
+        globalEventFired = true;
+        async.throwLater(e);
+    }
+
+    var domEventFired = false;
+    if (fireDomEvent) {
+        try {
+            domEventFired = fireDomEvent(name.toLowerCase(), {
+                reason: reason,
+                promise: promise
+            });
+        } catch (e) {
+            domEventFired = true;
+            async.throwLater(e);
+        }
+    }
+
+    if (!globalEventFired && !localEventFired && !domEventFired &&
+        name === "unhandledRejection") {
+        CapturedTrace.formatAndLogError(reason, "Unhandled rejection ");
+    }
+};
+
+function formatNonError(obj) {
+    var str;
+    if (typeof obj === "function") {
+        str = "[function " +
+            (obj.name || "anonymous") +
+            "]";
+    } else {
+        str = obj.toString();
+        var ruselessToString = /\[object [a-zA-Z0-9$_]+\]/;
+        if (ruselessToString.test(str)) {
+            try {
+                var newStr = JSON.stringify(obj);
+                str = newStr;
+            }
+            catch(e) {
+
+            }
+        }
+        if (str.length === 0) {
+            str = "(empty array)";
+        }
+    }
+    return ("(<" + snip(str) + ">, no stack trace)");
+}
+
+function snip(str) {
+    var maxChars = 41;
+    if (str.length < maxChars) {
+        return str;
+    }
+    return str.substr(0, maxChars - 3) + "...";
+}
+
+var shouldIgnore = function() { return false; };
+var parseLineInfoRegex = /[\/<\(]([^:\/]+):(\d+):(?:\d+)\)?\s*$/;
+function parseLineInfo(line) {
+    var matches = line.match(parseLineInfoRegex);
+    if (matches) {
+        return {
+            fileName: matches[1],
+            line: parseInt(matches[2], 10)
+        };
+    }
+}
+CapturedTrace.setBounds = function(firstLineError, lastLineError) {
+    if (!CapturedTrace.isSupported()) return;
+    var firstStackLines = firstLineError.stack.split("\n");
+    var lastStackLines = lastLineError.stack.split("\n");
+    var firstIndex = -1;
+    var lastIndex = -1;
+    var firstFileName;
+    var lastFileName;
+    for (var i = 0; i < firstStackLines.length; ++i) {
+        var result = parseLineInfo(firstStackLines[i]);
+        if (result) {
+            firstFileName = result.fileName;
+            firstIndex = result.line;
+            break;
+        }
+    }
+    for (var i = 0; i < lastStackLines.length; ++i) {
+        var result = parseLineInfo(lastStackLines[i]);
+        if (result) {
+            lastFileName = result.fileName;
+            lastIndex = result.line;
+            break;
+        }
+    }
+    if (firstIndex < 0 || lastIndex < 0 || !firstFileName || !lastFileName ||
+        firstFileName !== lastFileName || firstIndex >= lastIndex) {
+        return;
+    }
+
+    shouldIgnore = function(line) {
+        if (bluebirdFramePattern.test(line)) return true;
+        var info = parseLineInfo(line);
+        if (info) {
+            if (info.fileName === firstFileName &&
+                (firstIndex <= info.line && info.line <= lastIndex)) {
+                return true;
+            }
+        }
+        return false;
+    };
+};
+
+var captureStackTrace = (function stackDetection() {
+    var v8stackFramePattern = /^\s*at\s*/;
+    var v8stackFormatter = function(stack, error) {
+        if (typeof stack === "string") return stack;
+
+        if (error.name !== undefined &&
+            error.message !== undefined) {
+            return error.toString();
+        }
+        return formatNonError(error);
+    };
+
+    if (typeof Error.stackTraceLimit === "number" &&
+        typeof Error.captureStackTrace === "function") {
+        Error.stackTraceLimit = Error.stackTraceLimit + 6;
+        stackFramePattern = v8stackFramePattern;
+        formatStack = v8stackFormatter;
+        var captureStackTrace = Error.captureStackTrace;
+
+        shouldIgnore = function(line) {
+            return bluebirdFramePattern.test(line);
+        };
+        return function(receiver, ignoreUntil) {
+            Error.stackTraceLimit = Error.stackTraceLimit + 6;
+            captureStackTrace(receiver, ignoreUntil);
+            Error.stackTraceLimit = Error.stackTraceLimit - 6;
+        };
+    }
+    var err = new Error();
+
+    if (typeof err.stack === "string" &&
+        err.stack.split("\n")[0].indexOf("stackDetection@") >= 0) {
+        stackFramePattern = /@/;
+        formatStack = v8stackFormatter;
+        indentStackFrames = true;
+        return function captureStackTrace(o) {
+            o.stack = new Error().stack;
+        };
+    }
+
+    var hasStackAfterThrow;
+    try { throw new Error(); }
+    catch(e) {
+        hasStackAfterThrow = ("stack" in e);
+    }
+    if (!("stack" in err) && hasStackAfterThrow &&
+        typeof Error.stackTraceLimit === "number") {
+        stackFramePattern = v8stackFramePattern;
+        formatStack = v8stackFormatter;
+        return function captureStackTrace(o) {
+            Error.stackTraceLimit = Error.stackTraceLimit + 6;
+            try { throw new Error(); }
+            catch(e) { o.stack = e.stack; }
+            Error.stackTraceLimit = Error.stackTraceLimit - 6;
+        };
+    }
+
+    formatStack = function(stack, error) {
+        if (typeof stack === "string") return stack;
+
+        if ((typeof error === "object" ||
+            typeof error === "function") &&
+            error.name !== undefined &&
+            error.message !== undefined) {
+            return error.toString();
+        }
+        return formatNonError(error);
+    };
+
+    return null;
+
+})([]);
+
+var fireDomEvent;
+var fireGlobalEvent = (function() {
+    if (util.isNode) {
+        return function(name, reason, promise) {
+            if (name === "rejectionHandled") {
+                return process.emit(name, promise);
+            } else {
+                return process.emit(name, reason, promise);
+            }
+        };
+    } else {
+        var customEventWorks = false;
+        var anyEventWorks = true;
+        try {
+            var ev = new self.CustomEvent("test");
+            customEventWorks = ev instanceof CustomEvent;
+        } catch (e) {}
+        if (!customEventWorks) {
+            try {
+                var event = document.createEvent("CustomEvent");
+                event.initCustomEvent("testingtheevent", false, true, {});
+                self.dispatchEvent(event);
+            } catch (e) {
+                anyEventWorks = false;
+            }
+        }
+        if (anyEventWorks) {
+            fireDomEvent = function(type, detail) {
+                var event;
+                if (customEventWorks) {
+                    event = new self.CustomEvent(type, {
+                        detail: detail,
+                        bubbles: false,
+                        cancelable: true
+                    });
+                } else if (self.dispatchEvent) {
+                    event = document.createEvent("CustomEvent");
+                    event.initCustomEvent(type, false, true, detail);
+                }
+
+                return event ? !self.dispatchEvent(event) : false;
+            };
+        }
+
+        var toWindowMethodNameMap = {};
+        toWindowMethodNameMap["unhandledRejection"] = ("on" +
+            "unhandledRejection").toLowerCase();
+        toWindowMethodNameMap["rejectionHandled"] = ("on" +
+            "rejectionHandled").toLowerCase();
+
+        return function(name, reason, promise) {
+            var methodName = toWindowMethodNameMap[name];
+            var method = self[methodName];
+            if (!method) return false;
+            if (name === "rejectionHandled") {
+                method.call(self, promise);
+            } else {
+                method.call(self, reason, promise);
+            }
+            return true;
+        };
+    }
+})();
+
+if (typeof console !== "undefined" && typeof console.warn !== "undefined") {
+    warn = function (message) {
+        console.warn(message);
+    };
+    if (util.isNode && process.stderr.isTTY) {
+        warn = function(message) {
+            process.stderr.write("\u001b[31m" + message + "\u001b[39m\n");
+        };
+    } else if (!util.isNode && typeof (new Error().stack) === "string") {
+        warn = function(message) {
+            console.warn("%c" + message, "color: red");
+        };
+    }
+}
+
+return CapturedTrace;
+};
+
+},{"./async.js":2,"./util.js":38}],8:[function(_dereq_,module,exports){
+"use strict";
+module.exports = function(NEXT_FILTER) {
+var util = _dereq_("./util.js");
+var errors = _dereq_("./errors.js");
+var tryCatch = util.tryCatch;
+var errorObj = util.errorObj;
+var keys = _dereq_("./es5.js").keys;
+var TypeError = errors.TypeError;
+
+function CatchFilter(instances, callback, promise) {
+    this._instances = instances;
+    this._callback = callback;
+    this._promise = promise;
+}
+
+function safePredicate(predicate, e) {
+    var safeObject = {};
+    var retfilter = tryCatch(predicate).call(safeObject, e);
+
+    if (retfilter === errorObj) return retfilter;
+
+    var safeKeys = keys(safeObject);
+    if (safeKeys.length) {
+        errorObj.e = new TypeError("Catch filter must inherit from Error or be a simple predicate function\u000a\u000a    See http://goo.gl/o84o68\u000a");
+        return errorObj;
+    }
+    return retfilter;
+}
+
+CatchFilter.prototype.doFilter = function (e) {
+    var cb = this._callback;
+    var promise = this._promise;
+    var boundTo = promise._boundValue();
+    for (var i = 0, len = this._instances.length; i < len; ++i) {
+        var item = this._instances[i];
+        var itemIsErrorType = item === Error ||
+            (item != null && item.prototype instanceof Error);
+
+        if (itemIsErrorType && e instanceof item) {
+            var ret = tryCatch(cb).call(boundTo, e);
+            if (ret === errorObj) {
+                NEXT_FILTER.e = ret.e;
+                return NEXT_FILTER;
+            }
+            return ret;
+        } else if (typeof item === "function" && !itemIsErrorType) {
+            var shouldHandle = safePredicate(item, e);
+            if (shouldHandle === errorObj) {
+                e = errorObj.e;
+                break;
+            } else if (shouldHandle) {
+                var ret = tryCatch(cb).call(boundTo, e);
+                if (ret === errorObj) {
+                    NEXT_FILTER.e = ret.e;
+                    return NEXT_FILTER;
+                }
+                return ret;
+            }
+        }
+    }
+    NEXT_FILTER.e = e;
+    return NEXT_FILTER;
+};
+
+return CatchFilter;
+};
+
+},{"./errors.js":13,"./es5.js":14,"./util.js":38}],9:[function(_dereq_,module,exports){
+"use strict";
+module.exports = function(Promise, CapturedTrace, isDebugging) {
+var contextStack = [];
+function Context() {
+    this._trace = new CapturedTrace(peekContext());
+}
+Context.prototype._pushContext = function () {
+    if (!isDebugging()) return;
+    if (this._trace !== undefined) {
+        contextStack.push(this._trace);
+    }
+};
+
+Context.prototype._popContext = function () {
+    if (!isDebugging()) return;
+    if (this._trace !== undefined) {
+        contextStack.pop();
+    }
+};
+
+function createContext() {
+    if (isDebugging()) return new Context();
+}
+
+function peekContext() {
+    var lastIndex = contextStack.length - 1;
+    if (lastIndex >= 0) {
+        return contextStack[lastIndex];
+    }
+    return undefined;
+}
+
+Promise.prototype._peekContext = peekContext;
+Promise.prototype._pushContext = Context.prototype._pushContext;
+Promise.prototype._popContext = Context.prototype._popContext;
+
+return createContext;
+};
+
+},{}],10:[function(_dereq_,module,exports){
+"use strict";
+module.exports = function(Promise, CapturedTrace) {
+var getDomain = Promise._getDomain;
+var async = _dereq_("./async.js");
+var Warning = _dereq_("./errors.js").Warning;
+var util = _dereq_("./util.js");
+var canAttachTrace = util.canAttachTrace;
+var unhandledRejectionHandled;
+var possiblyUnhandledRejection;
+var debugging = false || (util.isNode &&
+                    (!!process.env["BLUEBIRD_DEBUG"] ||
+                     process.env["NODE_ENV"] === "development"));
+
+if (debugging) {
+    async.disableTrampolineIfNecessary();
+}
+
+Promise.prototype._ignoreRejections = function() {
+    this._unsetRejectionIsUnhandled();
+    this._bitField = this._bitField | 16777216;
+};
+
+Promise.prototype._ensurePossibleRejectionHandled = function () {
+    if ((this._bitField & 16777216) !== 0) return;
+    this._setRejectionIsUnhandled();
+    async.invokeLater(this._notifyUnhandledRejection, this, undefined);
+};
+
+Promise.prototype._notifyUnhandledRejectionIsHandled = function () {
+    CapturedTrace.fireRejectionEvent("rejectionHandled",
+                                  unhandledRejectionHandled, undefined, this);
+};
+
+Promise.prototype._notifyUnhandledRejection = function () {
+    if (this._isRejectionUnhandled()) {
+        var reason = this._getCarriedStackTrace() || this._settledValue;
+        this._setUnhandledRejectionIsNotified();
+        CapturedTrace.fireRejectionEvent("unhandledRejection",
+                                      possiblyUnhandledRejection, reason, this);
+    }
+};
+
+Promise.prototype._setUnhandledRejectionIsNotified = function () {
+    this._bitField = this._bitField | 524288;
+};
+
+Promise.prototype._unsetUnhandledRejectionIsNotified = function () {
+    this._bitField = this._bitField & (~524288);
+};
+
+Promise.prototype._isUnhandledRejectionNotified = function () {
+    return (this._bitField & 524288) > 0;
+};
+
+Promise.prototype._setRejectionIsUnhandled = function () {
+    this._bitField = this._bitField | 2097152;
+};
+
+Promise.prototype._unsetRejectionIsUnhandled = function () {
+    this._bitField = this._bitField & (~2097152);
+    if (this._isUnhandledRejectionNotified()) {
+        this._unsetUnhandledRejectionIsNotified();
+        this._notifyUnhandledRejectionIsHandled();
+    }
+};
+
+Promise.prototype._isRejectionUnhandled = function () {
+    return (this._bitField & 2097152) > 0;
+};
+
+Promise.prototype._setCarriedStackTrace = function (capturedTrace) {
+    this._bitField = this._bitField | 1048576;
+    this._fulfillmentHandler0 = capturedTrace;
+};
+
+Promise.prototype._isCarryingStackTrace = function () {
+    return (this._bitField & 1048576) > 0;
+};
+
+Promise.prototype._getCarriedStackTrace = function () {
+    return this._isCarryingStackTrace()
+        ? this._fulfillmentHandler0
+        : undefined;
+};
+
+Promise.prototype._captureStackTrace = function () {
+    if (debugging) {
+        this._trace = new CapturedTrace(this._peekContext());
+    }
+    return this;
+};
+
+Promise.prototype._attachExtraTrace = function (error, ignoreSelf) {
+    if (debugging && canAttachTrace(error)) {
+        var trace = this._trace;
+        if (trace !== undefined) {
+            if (ignoreSelf) trace = trace._parent;
+        }
+        if (trace !== undefined) {
+            trace.attachExtraTrace(error);
+        } else if (!error.__stackCleaned__) {
+            var parsed = CapturedTrace.parseStackAndMessage(error);
+            util.notEnumerableProp(error, "stack",
+                parsed.message + "\n" + parsed.stack.join("\n"));
+            util.notEnumerableProp(error, "__stackCleaned__", true);
+        }
+    }
+};
+
+Promise.prototype._warn = function(message) {
+    var warning = new Warning(message);
+    var ctx = this._peekContext();
+    if (ctx) {
+        ctx.attachExtraTrace(warning);
+    } else {
+        var parsed = CapturedTrace.parseStackAndMessage(warning);
+        warning.stack = parsed.message + "\n" + parsed.stack.join("\n");
+    }
+    CapturedTrace.formatAndLogError(warning, "");
+};
+
+Promise.onPossiblyUnhandledRejection = function (fn) {
+    var domain = getDomain();
+    possiblyUnhandledRejection =
+        typeof fn === "function" ? (domain === null ? fn : domain.bind(fn))
+                                 : undefined;
+};
+
+Promise.onUnhandledRejectionHandled = function (fn) {
+    var domain = getDomain();
+    unhandledRejectionHandled =
+        typeof fn === "function" ? (domain === null ? fn : domain.bind(fn))
+                                 : undefined;
+};
+
+Promise.longStackTraces = function () {
+    if (async.haveItemsQueued() &&
+        debugging === false
+   ) {
+        throw new Error("cannot enable long stack traces after promises have been created\u000a\u000a    See http://goo.gl/DT1qyG\u000a");
+    }
+    debugging = CapturedTrace.isSupported();
+    if (debugging) {
+        async.disableTrampolineIfNecessary();
+    }
+};
+
+Promise.hasLongStackTraces = function () {
+    return debugging && CapturedTrace.isSupported();
+};
+
+if (!CapturedTrace.isSupported()) {
+    Promise.longStackTraces = function(){};
+    debugging = false;
+}
+
+return function() {
+    return debugging;
+};
+};
+
+},{"./async.js":2,"./errors.js":13,"./util.js":38}],11:[function(_dereq_,module,exports){
+"use strict";
+var util = _dereq_("./util.js");
+var isPrimitive = util.isPrimitive;
+
+module.exports = function(Promise) {
+var returner = function () {
+    return this;
+};
+var thrower = function () {
+    throw this;
+};
+var returnUndefined = function() {};
+var throwUndefined = function() {
+    throw undefined;
+};
+
+var wrapper = function (value, action) {
+    if (action === 1) {
+        return function () {
+            throw value;
+        };
+    } else if (action === 2) {
+        return function () {
+            return value;
+        };
+    }
+};
+
+
+Promise.prototype["return"] =
+Promise.prototype.thenReturn = function (value) {
+    if (value === undefined) return this.then(returnUndefined);
+
+    if (isPrimitive(value)) {
+        return this._then(
+            wrapper(value, 2),
+            undefined,
+            undefined,
+            undefined,
+            undefined
+       );
+    }
+    return this._then(returner, undefined, undefined, value, undefined);
+};
+
+Promise.prototype["throw"] =
+Promise.prototype.thenThrow = function (reason) {
+    if (reason === undefined) return this.then(throwUndefined);
+
+    if (isPrimitive(reason)) {
+        return this._then(
+            wrapper(reason, 1),
+            undefined,
+            undefined,
+            undefined,
+            undefined
+       );
+    }
+    return this._then(thrower, undefined, undefined, reason, undefined);
+};
+};
+
+},{"./util.js":38}],12:[function(_dereq_,module,exports){
+"use strict";
+module.exports = function(Promise, INTERNAL) {
+var PromiseReduce = Promise.reduce;
+
+Promise.prototype.each = function (fn) {
+    return PromiseReduce(this, fn, null, INTERNAL);
+};
+
+Promise.each = function (promises, fn) {
+    return PromiseReduce(promises, fn, null, INTERNAL);
+};
+};
+
+},{}],13:[function(_dereq_,module,exports){
+"use strict";
+var es5 = _dereq_("./es5.js");
+var Objectfreeze = es5.freeze;
+var util = _dereq_("./util.js");
+var inherits = util.inherits;
+var notEnumerableProp = util.notEnumerableProp;
+
+function subError(nameProperty, defaultMessage) {
+    function SubError(message) {
+        if (!(this instanceof SubError)) return new SubError(message);
+        notEnumerableProp(this, "message",
+            typeof message === "string" ? message : defaultMessage);
+        notEnumerableProp(this, "name", nameProperty);
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, this.constructor);
+        } else {
+            Error.call(this);
+        }
+    }
+    inherits(SubError, Error);
+    return SubError;
+}
+
+var _TypeError, _RangeError;
+var Warning = subError("Warning", "warning");
+var CancellationError = subError("CancellationError", "cancellation error");
+var TimeoutError = subError("TimeoutError", "timeout error");
+var AggregateError = subError("AggregateError", "aggregate error");
+try {
+    _TypeError = TypeError;
+    _RangeError = RangeError;
+} catch(e) {
+    _TypeError = subError("TypeError", "type error");
+    _RangeError = subError("RangeError", "range error");
+}
+
+var methods = ("join pop push shift unshift slice filter forEach some " +
+    "every map indexOf lastIndexOf reduce reduceRight sort reverse").split(" ");
+
+for (var i = 0; i < methods.length; ++i) {
+    if (typeof Array.prototype[methods[i]] === "function") {
+        AggregateError.prototype[methods[i]] = Array.prototype[methods[i]];
+    }
+}
+
+es5.defineProperty(AggregateError.prototype, "length", {
+    value: 0,
+    configurable: false,
+    writable: true,
+    enumerable: true
+});
+AggregateError.prototype["isOperational"] = true;
+var level = 0;
+AggregateError.prototype.toString = function() {
+    var indent = Array(level * 4 + 1).join(" ");
+    var ret = "\n" + indent + "AggregateError of:" + "\n";
+    level++;
+    indent = Array(level * 4 + 1).join(" ");
+    for (var i = 0; i < this.length; ++i) {
+        var str = this[i] === this ? "[Circular AggregateError]" : this[i] + "";
+        var lines = str.split("\n");
+        for (var j = 0; j < lines.length; ++j) {
+            lines[j] = indent + lines[j];
+        }
+        str = lines.join("\n");
+        ret += str + "\n";
+    }
+    level--;
+    return ret;
+};
+
+function OperationalError(message) {
+    if (!(this instanceof OperationalError))
+        return new OperationalError(message);
+    notEnumerableProp(this, "name", "OperationalError");
+    notEnumerableProp(this, "message", message);
+    this.cause = message;
+    this["isOperational"] = true;
+
+    if (message instanceof Error) {
+        notEnumerableProp(this, "message", message.message);
+        notEnumerableProp(this, "stack", message.stack);
+    } else if (Error.captureStackTrace) {
+        Error.captureStackTrace(this, this.constructor);
+    }
+
+}
+inherits(OperationalError, Error);
+
+var errorTypes = Error["__BluebirdErrorTypes__"];
+if (!errorTypes) {
+    errorTypes = Objectfreeze({
+        CancellationError: CancellationError,
+        TimeoutError: TimeoutError,
+        OperationalError: OperationalError,
+        RejectionError: OperationalError,
+        AggregateError: AggregateError
+    });
+    notEnumerableProp(Error, "__BluebirdErrorTypes__", errorTypes);
+}
+
+module.exports = {
+    Error: Error,
+    TypeError: _TypeError,
+    RangeError: _RangeError,
+    CancellationError: errorTypes.CancellationError,
+    OperationalError: errorTypes.OperationalError,
+    TimeoutError: errorTypes.TimeoutError,
+    AggregateError: errorTypes.AggregateError,
+    Warning: Warning
+};
+
+},{"./es5.js":14,"./util.js":38}],14:[function(_dereq_,module,exports){
+var isES5 = (function(){
+    "use strict";
+    return this === undefined;
+})();
+
+if (isES5) {
+    module.exports = {
+        freeze: Object.freeze,
+        defineProperty: Object.defineProperty,
+        getDescriptor: Object.getOwnPropertyDescriptor,
+        keys: Object.keys,
+        names: Object.getOwnPropertyNames,
+        getPrototypeOf: Object.getPrototypeOf,
+        isArray: Array.isArray,
+        isES5: isES5,
+        propertyIsWritable: function(obj, prop) {
+            var descriptor = Object.getOwnPropertyDescriptor(obj, prop);
+            return !!(!descriptor || descriptor.writable || descriptor.set);
+        }
+    };
+} else {
+    var has = {}.hasOwnProperty;
+    var str = {}.toString;
+    var proto = {}.constructor.prototype;
+
+    var ObjectKeys = function (o) {
+        var ret = [];
+        for (var key in o) {
+            if (has.call(o, key)) {
+                ret.push(key);
+            }
+        }
+        return ret;
+    };
+
+    var ObjectGetDescriptor = function(o, key) {
+        return {value: o[key]};
+    };
+
+    var ObjectDefineProperty = function (o, key, desc) {
+        o[key] = desc.value;
+        return o;
+    };
+
+    var ObjectFreeze = function (obj) {
+        return obj;
+    };
+
+    var ObjectGetPrototypeOf = function (obj) {
+        try {
+            return Object(obj).constructor.prototype;
+        }
+        catch (e) {
+            return proto;
+        }
+    };
+
+    var ArrayIsArray = function (obj) {
+        try {
+            return str.call(obj) === "[object Array]";
+        }
+        catch(e) {
+            return false;
+        }
+    };
+
+    module.exports = {
+        isArray: ArrayIsArray,
+        keys: ObjectKeys,
+        names: ObjectKeys,
+        defineProperty: ObjectDefineProperty,
+        getDescriptor: ObjectGetDescriptor,
+        freeze: ObjectFreeze,
+        getPrototypeOf: ObjectGetPrototypeOf,
+        isES5: isES5,
+        propertyIsWritable: function() {
+            return true;
+        }
+    };
+}
+
+},{}],15:[function(_dereq_,module,exports){
+"use strict";
+module.exports = function(Promise, INTERNAL) {
+var PromiseMap = Promise.map;
+
+Promise.prototype.filter = function (fn, options) {
+    return PromiseMap(this, fn, options, INTERNAL);
+};
+
+Promise.filter = function (promises, fn, options) {
+    return PromiseMap(promises, fn, options, INTERNAL);
+};
+};
+
+},{}],16:[function(_dereq_,module,exports){
+"use strict";
+module.exports = function(Promise, NEXT_FILTER, tryConvertToPromise) {
+var util = _dereq_("./util.js");
+var isPrimitive = util.isPrimitive;
+var thrower = util.thrower;
+
+function returnThis() {
+    return this;
+}
+function throwThis() {
+    throw this;
+}
+function return$(r) {
+    return function() {
+        return r;
+    };
+}
+function throw$(r) {
+    return function() {
+        throw r;
+    };
+}
+function promisedFinally(ret, reasonOrValue, isFulfilled) {
+    var then;
+    if (isPrimitive(reasonOrValue)) {
+        then = isFulfilled ? return$(reasonOrValue) : throw$(reasonOrValue);
+    } else {
+        then = isFulfilled ? returnThis : throwThis;
+    }
+    return ret._then(then, thrower, undefined, reasonOrValue, undefined);
+}
+
+function finallyHandler(reasonOrValue) {
+    var promise = this.promise;
+    var handler = this.handler;
+
+    var ret = promise._isBound()
+                    ? handler.call(promise._boundValue())
+                    : handler();
+
+    if (ret !== undefined) {
+        var maybePromise = tryConvertToPromise(ret, promise);
+        if (maybePromise instanceof Promise) {
+            maybePromise = maybePromise._target();
+            return promisedFinally(maybePromise, reasonOrValue,
+                                    promise.isFulfilled());
+        }
+    }
+
+    if (promise.isRejected()) {
+        NEXT_FILTER.e = reasonOrValue;
+        return NEXT_FILTER;
+    } else {
+        return reasonOrValue;
+    }
+}
+
+function tapHandler(value) {
+    var promise = this.promise;
+    var handler = this.handler;
+
+    var ret = promise._isBound()
+                    ? handler.call(promise._boundValue(), value)
+                    : handler(value);
+
+    if (ret !== undefined) {
+        var maybePromise = tryConvertToPromise(ret, promise);
+        if (maybePromise instanceof Promise) {
+            maybePromise = maybePromise._target();
+            return promisedFinally(maybePromise, value, true);
+        }
+    }
+    return value;
+}
+
+Promise.prototype._passThroughHandler = function (handler, isFinally) {
+    if (typeof handler !== "function") return this.then();
+
+    var promiseAndHandler = {
+        promise: this,
+        handler: handler
+    };
+
+    return this._then(
+            isFinally ? finallyHandler : tapHandler,
+            isFinally ? finallyHandler : undefined, undefined,
+            promiseAndHandler, undefined);
+};
+
+Promise.prototype.lastly =
+Promise.prototype["finally"] = function (handler) {
+    return this._passThroughHandler(handler, true);
+};
+
+Promise.prototype.tap = function (handler) {
+    return this._passThroughHandler(handler, false);
+};
+};
+
+},{"./util.js":38}],17:[function(_dereq_,module,exports){
+"use strict";
+module.exports = function(Promise,
+                          apiRejection,
+                          INTERNAL,
+                          tryConvertToPromise) {
+var errors = _dereq_("./errors.js");
+var TypeError = errors.TypeError;
+var util = _dereq_("./util.js");
+var errorObj = util.errorObj;
+var tryCatch = util.tryCatch;
+var yieldHandlers = [];
+
+function promiseFromYieldHandler(value, yieldHandlers, traceParent) {
+    for (var i = 0; i < yieldHandlers.length; ++i) {
+        traceParent._pushContext();
+        var result = tryCatch(yieldHandlers[i])(value);
+        traceParent._popContext();
+        if (result === errorObj) {
+            traceParent._pushContext();
+            var ret = Promise.reject(errorObj.e);
+            traceParent._popContext();
+            return ret;
+        }
+        var maybePromise = tryConvertToPromise(result, traceParent);
+        if (maybePromise instanceof Promise) return maybePromise;
+    }
+    return null;
+}
+
+function PromiseSpawn(generatorFunction, receiver, yieldHandler, stack) {
+    var promise = this._promise = new Promise(INTERNAL);
+    promise._captureStackTrace();
+    this._stack = stack;
+    this._generatorFunction = generatorFunction;
+    this._receiver = receiver;
+    this._generator = undefined;
+    this._yieldHandlers = typeof yieldHandler === "function"
+        ? [yieldHandler].concat(yieldHandlers)
+        : yieldHandlers;
+}
+
+PromiseSpawn.prototype.promise = function () {
+    return this._promise;
+};
+
+PromiseSpawn.prototype._run = function () {
+    this._generator = this._generatorFunction.call(this._receiver);
+    this._receiver =
+        this._generatorFunction = undefined;
+    this._next(undefined);
+};
+
+PromiseSpawn.prototype._continue = function (result) {
+    if (result === errorObj) {
+        return this._promise._rejectCallback(result.e, false, true);
+    }
+
+    var value = result.value;
+    if (result.done === true) {
+        this._promise._resolveCallback(value);
+    } else {
+        var maybePromise = tryConvertToPromise(value, this._promise);
+        if (!(maybePromise instanceof Promise)) {
+            maybePromise =
+                promiseFromYieldHandler(maybePromise,
+                                        this._yieldHandlers,
+                                        this._promise);
+            if (maybePromise === null) {
+                this._throw(
+                    new TypeError(
+                        "A value %s was yielded that could not be treated as a promise\u000a\u000a    See http://goo.gl/4Y4pDk\u000a\u000a".replace("%s", value) +
+                        "From coroutine:\u000a" +
+                        this._stack.split("\n").slice(1, -7).join("\n")
+                    )
+                );
+                return;
+            }
+        }
+        maybePromise._then(
+            this._next,
+            this._throw,
+            undefined,
+            this,
+            null
+       );
+    }
+};
+
+PromiseSpawn.prototype._throw = function (reason) {
+    this._promise._attachExtraTrace(reason);
+    this._promise._pushContext();
+    var result = tryCatch(this._generator["throw"])
+        .call(this._generator, reason);
+    this._promise._popContext();
+    this._continue(result);
+};
+
+PromiseSpawn.prototype._next = function (value) {
+    this._promise._pushContext();
+    var result = tryCatch(this._generator.next).call(this._generator, value);
+    this._promise._popContext();
+    this._continue(result);
+};
+
+Promise.coroutine = function (generatorFunction, options) {
+    if (typeof generatorFunction !== "function") {
+        throw new TypeError("generatorFunction must be a function\u000a\u000a    See http://goo.gl/6Vqhm0\u000a");
+    }
+    var yieldHandler = Object(options).yieldHandler;
+    var PromiseSpawn$ = PromiseSpawn;
+    var stack = new Error().stack;
+    return function () {
+        var generator = generatorFunction.apply(this, arguments);
+        var spawn = new PromiseSpawn$(undefined, undefined, yieldHandler,
+                                      stack);
+        spawn._generator = generator;
+        spawn._next(undefined);
+        return spawn.promise();
+    };
+};
+
+Promise.coroutine.addYieldHandler = function(fn) {
+    if (typeof fn !== "function") throw new TypeError("fn must be a function\u000a\u000a    See http://goo.gl/916lJJ\u000a");
+    yieldHandlers.push(fn);
+};
+
+Promise.spawn = function (generatorFunction) {
+    if (typeof generatorFunction !== "function") {
+        return apiRejection("generatorFunction must be a function\u000a\u000a    See http://goo.gl/6Vqhm0\u000a");
+    }
+    var spawn = new PromiseSpawn(generatorFunction, this);
+    var ret = spawn.promise();
+    spawn._run(Promise.spawn);
+    return ret;
+};
+};
+
+},{"./errors.js":13,"./util.js":38}],18:[function(_dereq_,module,exports){
+"use strict";
+module.exports =
+function(Promise, PromiseArray, tryConvertToPromise, INTERNAL) {
+var util = _dereq_("./util.js");
+var canEvaluate = util.canEvaluate;
+var tryCatch = util.tryCatch;
+var errorObj = util.errorObj;
+var reject;
+
+if (!true) {
+if (canEvaluate) {
+    var thenCallback = function(i) {
+        return new Function("value", "holder", "                             \n\
+            'use strict';                                                    \n\
+            holder.pIndex = value;                                           \n\
+            holder.checkFulfillment(this);                                   \n\
+            ".replace(/Index/g, i));
+    };
+
+    var caller = function(count) {
+        var values = [];
+        for (var i = 1; i <= count; ++i) values.push("holder.p" + i);
+        return new Function("holder", "                                      \n\
+            'use strict';                                                    \n\
+            var callback = holder.fn;                                        \n\
+            return callback(values);                                         \n\
+            ".replace(/values/g, values.join(", ")));
+    };
+    var thenCallbacks = [];
+    var callers = [undefined];
+    for (var i = 1; i <= 5; ++i) {
+        thenCallbacks.push(thenCallback(i));
+        callers.push(caller(i));
+    }
+
+    var Holder = function(total, fn) {
+        this.p1 = this.p2 = this.p3 = this.p4 = this.p5 = null;
+        this.fn = fn;
+        this.total = total;
+        this.now = 0;
+    };
+
+    Holder.prototype.callers = callers;
+    Holder.prototype.checkFulfillment = function(promise) {
+        var now = this.now;
+        now++;
+        var total = this.total;
+        if (now >= total) {
+            var handler = this.callers[total];
+            promise._pushContext();
+            var ret = tryCatch(handler)(this);
+            promise._popContext();
+            if (ret === errorObj) {
+                promise._rejectCallback(ret.e, false, true);
+            } else {
+                promise._resolveCallback(ret);
+            }
+        } else {
+            this.now = now;
+        }
+    };
+
+    var reject = function (reason) {
+        this._reject(reason);
+    };
+}
+}
+
+Promise.join = function () {
+    var last = arguments.length - 1;
+    var fn;
+    if (last > 0 && typeof arguments[last] === "function") {
+        fn = arguments[last];
+        if (!true) {
+            if (last < 6 && canEvaluate) {
+                var ret = new Promise(INTERNAL);
+                ret._captureStackTrace();
+                var holder = new Holder(last, fn);
+                var callbacks = thenCallbacks;
+                for (var i = 0; i < last; ++i) {
+                    var maybePromise = tryConvertToPromise(arguments[i], ret);
+                    if (maybePromise instanceof Promise) {
+                        maybePromise = maybePromise._target();
+                        if (maybePromise._isPending()) {
+                            maybePromise._then(callbacks[i], reject,
+                                               undefined, ret, holder);
+                        } else if (maybePromise._isFulfilled()) {
+                            callbacks[i].call(ret,
+                                              maybePromise._value(), holder);
+                        } else {
+                            ret._reject(maybePromise._reason());
+                        }
+                    } else {
+                        callbacks[i].call(ret, maybePromise, holder);
+                    }
+                }
+                return ret;
+            }
+        }
+    }
+    var $_len = arguments.length;var args = new Array($_len); for(var $_i = 0; $_i < $_len; ++$_i) {args[$_i] = arguments[$_i];}
+    if (fn) args.pop();
+    var ret = new PromiseArray(args).promise();
+    return fn !== undefined ? ret.spread(fn) : ret;
+};
+
+};
+
+},{"./util.js":38}],19:[function(_dereq_,module,exports){
+"use strict";
+module.exports = function(Promise,
+                          PromiseArray,
+                          apiRejection,
+                          tryConvertToPromise,
+                          INTERNAL) {
+var getDomain = Promise._getDomain;
+var async = _dereq_("./async.js");
+var util = _dereq_("./util.js");
+var tryCatch = util.tryCatch;
+var errorObj = util.errorObj;
+var PENDING = {};
+var EMPTY_ARRAY = [];
+
+function MappingPromiseArray(promises, fn, limit, _filter) {
+    this.constructor$(promises);
+    this._promise._captureStackTrace();
+    var domain = getDomain();
+    this._callback = domain === null ? fn : domain.bind(fn);
+    this._preservedValues = _filter === INTERNAL
+        ? new Array(this.length())
+        : null;
+    this._limit = limit;
+    this._inFlight = 0;
+    this._queue = limit >= 1 ? [] : EMPTY_ARRAY;
+    async.invoke(init, this, undefined);
+}
+util.inherits(MappingPromiseArray, PromiseArray);
+function init() {this._init$(undefined, -2);}
+
+MappingPromiseArray.prototype._init = function () {};
+
+MappingPromiseArray.prototype._promiseFulfilled = function (value, index) {
+    var values = this._values;
+    var length = this.length();
+    var preservedValues = this._preservedValues;
+    var limit = this._limit;
+    if (values[index] === PENDING) {
+        values[index] = value;
+        if (limit >= 1) {
+            this._inFlight--;
+            this._drainQueue();
+            if (this._isResolved()) return;
+        }
+    } else {
+        if (limit >= 1 && this._inFlight >= limit) {
+            values[index] = value;
+            this._queue.push(index);
+            return;
+        }
+        if (preservedValues !== null) preservedValues[index] = value;
+
+        var callback = this._callback;
+        var receiver = this._promise._boundValue();
+        this._promise._pushContext();
+        var ret = tryCatch(callback).call(receiver, value, index, length);
+        this._promise._popContext();
+        if (ret === errorObj) return this._reject(ret.e);
+
+        var maybePromise = tryConvertToPromise(ret, this._promise);
+        if (maybePromise instanceof Promise) {
+            maybePromise = maybePromise._target();
+            if (maybePromise._isPending()) {
+                if (limit >= 1) this._inFlight++;
+                values[index] = PENDING;
+                return maybePromise._proxyPromiseArray(this, index);
+            } else if (maybePromise._isFulfilled()) {
+                ret = maybePromise._value();
+            } else {
+                return this._reject(maybePromise._reason());
+            }
+        }
+        values[index] = ret;
+    }
+    var totalResolved = ++this._totalResolved;
+    if (totalResolved >= length) {
+        if (preservedValues !== null) {
+            this._filter(values, preservedValues);
+        } else {
+            this._resolve(values);
+        }
+
+    }
+};
+
+MappingPromiseArray.prototype._drainQueue = function () {
+    var queue = this._queue;
+    var limit = this._limit;
+    var values = this._values;
+    while (queue.length > 0 && this._inFlight < limit) {
+        if (this._isResolved()) return;
+        var index = queue.pop();
+        this._promiseFulfilled(values[index], index);
+    }
+};
+
+MappingPromiseArray.prototype._filter = function (booleans, values) {
+    var len = values.length;
+    var ret = new Array(len);
+    var j = 0;
+    for (var i = 0; i < len; ++i) {
+        if (booleans[i]) ret[j++] = values[i];
+    }
+    ret.length = j;
+    this._resolve(ret);
+};
+
+MappingPromiseArray.prototype.preservedValues = function () {
+    return this._preservedValues;
+};
+
+function map(promises, fn, options, _filter) {
+    var limit = typeof options === "object" && options !== null
+        ? options.concurrency
+        : 0;
+    limit = typeof limit === "number" &&
+        isFinite(limit) && limit >= 1 ? limit : 0;
+    return new MappingPromiseArray(promises, fn, limit, _filter);
+}
+
+Promise.prototype.map = function (fn, options) {
+    if (typeof fn !== "function") return apiRejection("fn must be a function\u000a\u000a    See http://goo.gl/916lJJ\u000a");
+
+    return map(this, fn, options, null).promise();
+};
+
+Promise.map = function (promises, fn, options, _filter) {
+    if (typeof fn !== "function") return apiRejection("fn must be a function\u000a\u000a    See http://goo.gl/916lJJ\u000a");
+    return map(promises, fn, options, _filter).promise();
+};
+
+
+};
+
+},{"./async.js":2,"./util.js":38}],20:[function(_dereq_,module,exports){
+"use strict";
+module.exports =
+function(Promise, INTERNAL, tryConvertToPromise, apiRejection) {
+var util = _dereq_("./util.js");
+var tryCatch = util.tryCatch;
+
+Promise.method = function (fn) {
+    if (typeof fn !== "function") {
+        throw new Promise.TypeError("fn must be a function\u000a\u000a    See http://goo.gl/916lJJ\u000a");
+    }
+    return function () {
+        var ret = new Promise(INTERNAL);
+        ret._captureStackTrace();
+        ret._pushContext();
+        var value = tryCatch(fn).apply(this, arguments);
+        ret._popContext();
+        ret._resolveFromSyncValue(value);
+        return ret;
+    };
+};
+
+Promise.attempt = Promise["try"] = function (fn, args, ctx) {
+    if (typeof fn !== "function") {
+        return apiRejection("fn must be a function\u000a\u000a    See http://goo.gl/916lJJ\u000a");
+    }
+    var ret = new Promise(INTERNAL);
+    ret._captureStackTrace();
+    ret._pushContext();
+    var value = util.isArray(args)
+        ? tryCatch(fn).apply(ctx, args)
+        : tryCatch(fn).call(ctx, args);
+    ret._popContext();
+    ret._resolveFromSyncValue(value);
+    return ret;
+};
+
+Promise.prototype._resolveFromSyncValue = function (value) {
+    if (value === util.errorObj) {
+        this._rejectCallback(value.e, false, true);
+    } else {
+        this._resolveCallback(value, true);
+    }
+};
+};
+
+},{"./util.js":38}],21:[function(_dereq_,module,exports){
+"use strict";
+module.exports = function(Promise) {
+var util = _dereq_("./util.js");
+var async = _dereq_("./async.js");
+var tryCatch = util.tryCatch;
+var errorObj = util.errorObj;
+
+function spreadAdapter(val, nodeback) {
+    var promise = this;
+    if (!util.isArray(val)) return successAdapter.call(promise, val, nodeback);
+    var ret =
+        tryCatch(nodeback).apply(promise._boundValue(), [null].concat(val));
+    if (ret === errorObj) {
+        async.throwLater(ret.e);
+    }
+}
+
+function successAdapter(val, nodeback) {
+    var promise = this;
+    var receiver = promise._boundValue();
+    var ret = val === undefined
+        ? tryCatch(nodeback).call(receiver, null)
+        : tryCatch(nodeback).call(receiver, null, val);
+    if (ret === errorObj) {
+        async.throwLater(ret.e);
+    }
+}
+function errorAdapter(reason, nodeback) {
+    var promise = this;
+    if (!reason) {
+        var target = promise._target();
+        var newReason = target._getCarriedStackTrace();
+        newReason.cause = reason;
+        reason = newReason;
+    }
+    var ret = tryCatch(nodeback).call(promise._boundValue(), reason);
+    if (ret === errorObj) {
+        async.throwLater(ret.e);
+    }
+}
+
+Promise.prototype.asCallback =
+Promise.prototype.nodeify = function (nodeback, options) {
+    if (typeof nodeback == "function") {
+        var adapter = successAdapter;
+        if (options !== undefined && Object(options).spread) {
+            adapter = spreadAdapter;
+        }
+        this._then(
+            adapter,
+            errorAdapter,
+            undefined,
+            this,
+            nodeback
+        );
+    }
+    return this;
+};
+};
+
+},{"./async.js":2,"./util.js":38}],22:[function(_dereq_,module,exports){
+"use strict";
+module.exports = function(Promise, PromiseArray) {
+var util = _dereq_("./util.js");
+var async = _dereq_("./async.js");
+var tryCatch = util.tryCatch;
+var errorObj = util.errorObj;
+
+Promise.prototype.progressed = function (handler) {
+    return this._then(undefined, undefined, handler, undefined, undefined);
+};
+
+Promise.prototype._progress = function (progressValue) {
+    if (this._isFollowingOrFulfilledOrRejected()) return;
+    this._target()._progressUnchecked(progressValue);
+
+};
+
+Promise.prototype._progressHandlerAt = function (index) {
+    return index === 0
+        ? this._progressHandler0
+        : this[(index << 2) + index - 5 + 2];
+};
+
+Promise.prototype._doProgressWith = function (progression) {
+    var progressValue = progression.value;
+    var handler = progression.handler;
+    var promise = progression.promise;
+    var receiver = progression.receiver;
+
+    var ret = tryCatch(handler).call(receiver, progressValue);
+    if (ret === errorObj) {
+        if (ret.e != null &&
+            ret.e.name !== "StopProgressPropagation") {
+            var trace = util.canAttachTrace(ret.e)
+                ? ret.e : new Error(util.toString(ret.e));
+            promise._attachExtraTrace(trace);
+            promise._progress(ret.e);
+        }
+    } else if (ret instanceof Promise) {
+        ret._then(promise._progress, null, null, promise, undefined);
+    } else {
+        promise._progress(ret);
+    }
+};
+
+
+Promise.prototype._progressUnchecked = function (progressValue) {
+    var len = this._length();
+    var progress = this._progress;
+    for (var i = 0; i < len; i++) {
+        var handler = this._progressHandlerAt(i);
+        var promise = this._promiseAt(i);
+        if (!(promise instanceof Promise)) {
+            var receiver = this._receiverAt(i);
+            if (typeof handler === "function") {
+                handler.call(receiver, progressValue, promise);
+            } else if (receiver instanceof PromiseArray &&
+                       !receiver._isResolved()) {
+                receiver._promiseProgressed(progressValue, promise);
+            }
+            continue;
+        }
+
+        if (typeof handler === "function") {
+            async.invoke(this._doProgressWith, this, {
+                handler: handler,
+                promise: promise,
+                receiver: this._receiverAt(i),
+                value: progressValue
+            });
+        } else {
+            async.invoke(progress, promise, progressValue);
+        }
+    }
+};
+};
+
+},{"./async.js":2,"./util.js":38}],23:[function(_dereq_,module,exports){
+"use strict";
+module.exports = function() {
+var makeSelfResolutionError = function () {
+    return new TypeError("circular promise resolution chain\u000a\u000a    See http://goo.gl/LhFpo0\u000a");
+};
+var reflect = function() {
+    return new Promise.PromiseInspection(this._target());
+};
+var apiRejection = function(msg) {
+    return Promise.reject(new TypeError(msg));
+};
+
+var util = _dereq_("./util.js");
+
+var getDomain;
+if (util.isNode) {
+    getDomain = function() {
+        var ret = process.domain;
+        if (ret === undefined) ret = null;
+        return ret;
+    };
+} else {
+    getDomain = function() {
+        return null;
+    };
+}
+util.notEnumerableProp(Promise, "_getDomain", getDomain);
+
+var async = _dereq_("./async.js");
+var errors = _dereq_("./errors.js");
+var TypeError = Promise.TypeError = errors.TypeError;
+Promise.RangeError = errors.RangeError;
+Promise.CancellationError = errors.CancellationError;
+Promise.TimeoutError = errors.TimeoutError;
+Promise.OperationalError = errors.OperationalError;
+Promise.RejectionError = errors.OperationalError;
+Promise.AggregateError = errors.AggregateError;
+var INTERNAL = function(){};
+var APPLY = {};
+var NEXT_FILTER = {e: null};
+var tryConvertToPromise = _dereq_("./thenables.js")(Promise, INTERNAL);
+var PromiseArray =
+    _dereq_("./promise_array.js")(Promise, INTERNAL,
+                                    tryConvertToPromise, apiRejection);
+var CapturedTrace = _dereq_("./captured_trace.js")();
+var isDebugging = _dereq_("./debuggability.js")(Promise, CapturedTrace);
+ /*jshint unused:false*/
+var createContext =
+    _dereq_("./context.js")(Promise, CapturedTrace, isDebugging);
+var CatchFilter = _dereq_("./catch_filter.js")(NEXT_FILTER);
+var PromiseResolver = _dereq_("./promise_resolver.js");
+var nodebackForPromise = PromiseResolver._nodebackForPromise;
+var errorObj = util.errorObj;
+var tryCatch = util.tryCatch;
+function Promise(resolver) {
+    if (typeof resolver !== "function") {
+        throw new TypeError("the promise constructor requires a resolver function\u000a\u000a    See http://goo.gl/EC22Yn\u000a");
+    }
+    if (this.constructor !== Promise) {
+        throw new TypeError("the promise constructor cannot be invoked directly\u000a\u000a    See http://goo.gl/KsIlge\u000a");
+    }
+    this._bitField = 0;
+    this._fulfillmentHandler0 = undefined;
+    this._rejectionHandler0 = undefined;
+    this._progressHandler0 = undefined;
+    this._promise0 = undefined;
+    this._receiver0 = undefined;
+    this._settledValue = undefined;
+    if (resolver !== INTERNAL) this._resolveFromResolver(resolver);
+}
+
+Promise.prototype.toString = function () {
+    return "[object Promise]";
+};
+
+Promise.prototype.caught = Promise.prototype["catch"] = function (fn) {
+    var len = arguments.length;
+    if (len > 1) {
+        var catchInstances = new Array(len - 1),
+            j = 0, i;
+        for (i = 0; i < len - 1; ++i) {
+            var item = arguments[i];
+            if (typeof item === "function") {
+                catchInstances[j++] = item;
+            } else {
+                return Promise.reject(
+                    new TypeError("Catch filter must inherit from Error or be a simple predicate function\u000a\u000a    See http://goo.gl/o84o68\u000a"));
+            }
+        }
+        catchInstances.length = j;
+        fn = arguments[i];
+        var catchFilter = new CatchFilter(catchInstances, fn, this);
+        return this._then(undefined, catchFilter.doFilter, undefined,
+            catchFilter, undefined);
+    }
+    return this._then(undefined, fn, undefined, undefined, undefined);
+};
+
+Promise.prototype.reflect = function () {
+    return this._then(reflect, reflect, undefined, this, undefined);
+};
+
+Promise.prototype.then = function (didFulfill, didReject, didProgress) {
+    if (isDebugging() && arguments.length > 0 &&
+        typeof didFulfill !== "function" &&
+        typeof didReject !== "function") {
+        var msg = ".then() only accepts functions but was passed: " +
+                util.classString(didFulfill);
+        if (arguments.length > 1) {
+            msg += ", " + util.classString(didReject);
+        }
+        this._warn(msg);
+    }
+    return this._then(didFulfill, didReject, didProgress,
+        undefined, undefined);
+};
+
+Promise.prototype.done = function (didFulfill, didReject, didProgress) {
+    var promise = this._then(didFulfill, didReject, didProgress,
+        undefined, undefined);
+    promise._setIsFinal();
+};
+
+Promise.prototype.spread = function (didFulfill, didReject) {
+    return this.all()._then(didFulfill, didReject, undefined, APPLY, undefined);
+};
+
+Promise.prototype.isCancellable = function () {
+    return !this.isResolved() &&
+        this._cancellable();
+};
+
+Promise.prototype.toJSON = function () {
+    var ret = {
+        isFulfilled: false,
+        isRejected: false,
+        fulfillmentValue: undefined,
+        rejectionReason: undefined
+    };
+    if (this.isFulfilled()) {
+        ret.fulfillmentValue = this.value();
+        ret.isFulfilled = true;
+    } else if (this.isRejected()) {
+        ret.rejectionReason = this.reason();
+        ret.isRejected = true;
+    }
+    return ret;
+};
+
+Promise.prototype.all = function () {
+    return new PromiseArray(this).promise();
+};
+
+Promise.prototype.error = function (fn) {
+    return this.caught(util.originatesFromRejection, fn);
+};
+
+Promise.is = function (val) {
+    return val instanceof Promise;
+};
+
+Promise.fromNode = function(fn) {
+    var ret = new Promise(INTERNAL);
+    var result = tryCatch(fn)(nodebackForPromise(ret));
+    if (result === errorObj) {
+        ret._rejectCallback(result.e, true, true);
+    }
+    return ret;
+};
+
+Promise.all = function (promises) {
+    return new PromiseArray(promises).promise();
+};
+
+Promise.defer = Promise.pending = function () {
+    var promise = new Promise(INTERNAL);
+    return new PromiseResolver(promise);
+};
+
+Promise.cast = function (obj) {
+    var ret = tryConvertToPromise(obj);
+    if (!(ret instanceof Promise)) {
+        var val = ret;
+        ret = new Promise(INTERNAL);
+        ret._fulfillUnchecked(val);
+    }
+    return ret;
+};
+
+Promise.resolve = Promise.fulfilled = Promise.cast;
+
+Promise.reject = Promise.rejected = function (reason) {
+    var ret = new Promise(INTERNAL);
+    ret._captureStackTrace();
+    ret._rejectCallback(reason, true);
+    return ret;
+};
+
+Promise.setScheduler = function(fn) {
+    if (typeof fn !== "function") throw new TypeError("fn must be a function\u000a\u000a    See http://goo.gl/916lJJ\u000a");
+    var prev = async._schedule;
+    async._schedule = fn;
+    return prev;
+};
+
+Promise.prototype._then = function (
+    didFulfill,
+    didReject,
+    didProgress,
+    receiver,
+    internalData
+) {
+    var haveInternalData = internalData !== undefined;
+    var ret = haveInternalData ? internalData : new Promise(INTERNAL);
+
+    if (!haveInternalData) {
+        ret._propagateFrom(this, 4 | 1);
+        ret._captureStackTrace();
+    }
+
+    var target = this._target();
+    if (target !== this) {
+        if (receiver === undefined) receiver = this._boundTo;
+        if (!haveInternalData) ret._setIsMigrated();
+    }
+
+    var callbackIndex = target._addCallbacks(didFulfill,
+                                             didReject,
+                                             didProgress,
+                                             ret,
+                                             receiver,
+                                             getDomain());
+
+    if (target._isResolved() && !target._isSettlePromisesQueued()) {
+        async.invoke(
+            target._settlePromiseAtPostResolution, target, callbackIndex);
+    }
+
+    return ret;
+};
+
+Promise.prototype._settlePromiseAtPostResolution = function (index) {
+    if (this._isRejectionUnhandled()) this._unsetRejectionIsUnhandled();
+    this._settlePromiseAt(index);
+};
+
+Promise.prototype._length = function () {
+    return this._bitField & 131071;
+};
+
+Promise.prototype._isFollowingOrFulfilledOrRejected = function () {
+    return (this._bitField & 939524096) > 0;
+};
+
+Promise.prototype._isFollowing = function () {
+    return (this._bitField & 536870912) === 536870912;
+};
+
+Promise.prototype._setLength = function (len) {
+    this._bitField = (this._bitField & -131072) |
+        (len & 131071);
+};
+
+Promise.prototype._setFulfilled = function () {
+    this._bitField = this._bitField | 268435456;
+};
+
+Promise.prototype._setRejected = function () {
+    this._bitField = this._bitField | 134217728;
+};
+
+Promise.prototype._setFollowing = function () {
+    this._bitField = this._bitField | 536870912;
+};
+
+Promise.prototype._setIsFinal = function () {
+    this._bitField = this._bitField | 33554432;
+};
+
+Promise.prototype._isFinal = function () {
+    return (this._bitField & 33554432) > 0;
+};
+
+Promise.prototype._cancellable = function () {
+    return (this._bitField & 67108864) > 0;
+};
+
+Promise.prototype._setCancellable = function () {
+    this._bitField = this._bitField | 67108864;
+};
+
+Promise.prototype._unsetCancellable = function () {
+    this._bitField = this._bitField & (~67108864);
+};
+
+Promise.prototype._setIsMigrated = function () {
+    this._bitField = this._bitField | 4194304;
+};
+
+Promise.prototype._unsetIsMigrated = function () {
+    this._bitField = this._bitField & (~4194304);
+};
+
+Promise.prototype._isMigrated = function () {
+    return (this._bitField & 4194304) > 0;
+};
+
+Promise.prototype._receiverAt = function (index) {
+    var ret = index === 0
+        ? this._receiver0
+        : this[
+            index * 5 - 5 + 4];
+    if (ret === undefined && this._isBound()) {
+        return this._boundValue();
+    }
+    return ret;
+};
+
+Promise.prototype._promiseAt = function (index) {
+    return index === 0
+        ? this._promise0
+        : this[index * 5 - 5 + 3];
+};
+
+Promise.prototype._fulfillmentHandlerAt = function (index) {
+    return index === 0
+        ? this._fulfillmentHandler0
+        : this[index * 5 - 5 + 0];
+};
+
+Promise.prototype._rejectionHandlerAt = function (index) {
+    return index === 0
+        ? this._rejectionHandler0
+        : this[index * 5 - 5 + 1];
+};
+
+Promise.prototype._boundValue = function() {
+    var ret = this._boundTo;
+    if (ret !== undefined) {
+        if (ret instanceof Promise) {
+            if (ret.isFulfilled()) {
+                return ret.value();
+            } else {
+                return undefined;
+            }
+        }
+    }
+    return ret;
+};
+
+Promise.prototype._migrateCallbacks = function (follower, index) {
+    var fulfill = follower._fulfillmentHandlerAt(index);
+    var reject = follower._rejectionHandlerAt(index);
+    var progress = follower._progressHandlerAt(index);
+    var promise = follower._promiseAt(index);
+    var receiver = follower._receiverAt(index);
+    if (promise instanceof Promise) promise._setIsMigrated();
+    this._addCallbacks(fulfill, reject, progress, promise, receiver, null);
+};
+
+Promise.prototype._addCallbacks = function (
+    fulfill,
+    reject,
+    progress,
+    promise,
+    receiver,
+    domain
+) {
+    var index = this._length();
+
+    if (index >= 131071 - 5) {
+        index = 0;
+        this._setLength(0);
+    }
+
+    if (index === 0) {
+        this._promise0 = promise;
+        if (receiver !== undefined) this._receiver0 = receiver;
+        if (typeof fulfill === "function" && !this._isCarryingStackTrace()) {
+            this._fulfillmentHandler0 =
+                domain === null ? fulfill : domain.bind(fulfill);
+        }
+        if (typeof reject === "function") {
+            this._rejectionHandler0 =
+                domain === null ? reject : domain.bind(reject);
+        }
+        if (typeof progress === "function") {
+            this._progressHandler0 =
+                domain === null ? progress : domain.bind(progress);
+        }
+    } else {
+        var base = index * 5 - 5;
+        this[base + 3] = promise;
+        this[base + 4] = receiver;
+        if (typeof fulfill === "function") {
+            this[base + 0] =
+                domain === null ? fulfill : domain.bind(fulfill);
+        }
+        if (typeof reject === "function") {
+            this[base + 1] =
+                domain === null ? reject : domain.bind(reject);
+        }
+        if (typeof progress === "function") {
+            this[base + 2] =
+                domain === null ? progress : domain.bind(progress);
+        }
+    }
+    this._setLength(index + 1);
+    return index;
+};
+
+Promise.prototype._setProxyHandlers = function (receiver, promiseSlotValue) {
+    var index = this._length();
+
+    if (index >= 131071 - 5) {
+        index = 0;
+        this._setLength(0);
+    }
+    if (index === 0) {
+        this._promise0 = promiseSlotValue;
+        this._receiver0 = receiver;
+    } else {
+        var base = index * 5 - 5;
+        this[base + 3] = promiseSlotValue;
+        this[base + 4] = receiver;
+    }
+    this._setLength(index + 1);
+};
+
+Promise.prototype._proxyPromiseArray = function (promiseArray, index) {
+    this._setProxyHandlers(promiseArray, index);
+};
+
+Promise.prototype._resolveCallback = function(value, shouldBind) {
+    if (this._isFollowingOrFulfilledOrRejected()) return;
+    if (value === this)
+        return this._rejectCallback(makeSelfResolutionError(), false, true);
+    var maybePromise = tryConvertToPromise(value, this);
+    if (!(maybePromise instanceof Promise)) return this._fulfill(value);
+
+    var propagationFlags = 1 | (shouldBind ? 4 : 0);
+    this._propagateFrom(maybePromise, propagationFlags);
+    var promise = maybePromise._target();
+    if (promise._isPending()) {
+        var len = this._length();
+        for (var i = 0; i < len; ++i) {
+            promise._migrateCallbacks(this, i);
+        }
+        this._setFollowing();
+        this._setLength(0);
+        this._setFollowee(promise);
+    } else if (promise._isFulfilled()) {
+        this._fulfillUnchecked(promise._value());
+    } else {
+        this._rejectUnchecked(promise._reason(),
+            promise._getCarriedStackTrace());
+    }
+};
+
+Promise.prototype._rejectCallback =
+function(reason, synchronous, shouldNotMarkOriginatingFromRejection) {
+    if (!shouldNotMarkOriginatingFromRejection) {
+        util.markAsOriginatingFromRejection(reason);
+    }
+    var trace = util.ensureErrorObject(reason);
+    var hasStack = trace === reason;
+    this._attachExtraTrace(trace, synchronous ? hasStack : false);
+    this._reject(reason, hasStack ? undefined : trace);
+};
+
+Promise.prototype._resolveFromResolver = function (resolver) {
+    var promise = this;
+    this._captureStackTrace();
+    this._pushContext();
+    var synchronous = true;
+    var r = tryCatch(resolver)(function(value) {
+        if (promise === null) return;
+        promise._resolveCallback(value);
+        promise = null;
+    }, function (reason) {
+        if (promise === null) return;
+        promise._rejectCallback(reason, synchronous);
+        promise = null;
+    });
+    synchronous = false;
+    this._popContext();
+
+    if (r !== undefined && r === errorObj && promise !== null) {
+        promise._rejectCallback(r.e, true, true);
+        promise = null;
+    }
+};
+
+Promise.prototype._settlePromiseFromHandler = function (
+    handler, receiver, value, promise
+) {
+    if (promise._isRejected()) return;
+    promise._pushContext();
+    var x;
+    if (receiver === APPLY && !this._isRejected()) {
+        x = tryCatch(handler).apply(this._boundValue(), value);
+    } else {
+        x = tryCatch(handler).call(receiver, value);
+    }
+    promise._popContext();
+
+    if (x === errorObj || x === promise || x === NEXT_FILTER) {
+        var err = x === promise ? makeSelfResolutionError() : x.e;
+        promise._rejectCallback(err, false, true);
+    } else {
+        promise._resolveCallback(x);
+    }
+};
+
+Promise.prototype._target = function() {
+    var ret = this;
+    while (ret._isFollowing()) ret = ret._followee();
+    return ret;
+};
+
+Promise.prototype._followee = function() {
+    return this._rejectionHandler0;
+};
+
+Promise.prototype._setFollowee = function(promise) {
+    this._rejectionHandler0 = promise;
+};
+
+Promise.prototype._cleanValues = function () {
+    if (this._cancellable()) {
+        this._cancellationParent = undefined;
+    }
+};
+
+Promise.prototype._propagateFrom = function (parent, flags) {
+    if ((flags & 1) > 0 && parent._cancellable()) {
+        this._setCancellable();
+        this._cancellationParent = parent;
+    }
+    if ((flags & 4) > 0 && parent._isBound()) {
+        this._setBoundTo(parent._boundTo);
+    }
+};
+
+Promise.prototype._fulfill = function (value) {
+    if (this._isFollowingOrFulfilledOrRejected()) return;
+    this._fulfillUnchecked(value);
+};
+
+Promise.prototype._reject = function (reason, carriedStackTrace) {
+    if (this._isFollowingOrFulfilledOrRejected()) return;
+    this._rejectUnchecked(reason, carriedStackTrace);
+};
+
+Promise.prototype._settlePromiseAt = function (index) {
+    var promise = this._promiseAt(index);
+    var isPromise = promise instanceof Promise;
+
+    if (isPromise && promise._isMigrated()) {
+        promise._unsetIsMigrated();
+        return async.invoke(this._settlePromiseAt, this, index);
+    }
+    var handler = this._isFulfilled()
+        ? this._fulfillmentHandlerAt(index)
+        : this._rejectionHandlerAt(index);
+
+    var carriedStackTrace =
+        this._isCarryingStackTrace() ? this._getCarriedStackTrace() : undefined;
+    var value = this._settledValue;
+    var receiver = this._receiverAt(index);
+    this._clearCallbackDataAtIndex(index);
+
+    if (typeof handler === "function") {
+        if (!isPromise) {
+            handler.call(receiver, value, promise);
+        } else {
+            this._settlePromiseFromHandler(handler, receiver, value, promise);
+        }
+    } else if (receiver instanceof PromiseArray) {
+        if (!receiver._isResolved()) {
+            if (this._isFulfilled()) {
+                receiver._promiseFulfilled(value, promise);
+            }
+            else {
+                receiver._promiseRejected(value, promise);
+            }
+        }
+    } else if (isPromise) {
+        if (this._isFulfilled()) {
+            promise._fulfill(value);
+        } else {
+            promise._reject(value, carriedStackTrace);
+        }
+    }
+
+    if (index >= 4 && (index & 31) === 4)
+        async.invokeLater(this._setLength, this, 0);
+};
+
+Promise.prototype._clearCallbackDataAtIndex = function(index) {
+    if (index === 0) {
+        if (!this._isCarryingStackTrace()) {
+            this._fulfillmentHandler0 = undefined;
+        }
+        this._rejectionHandler0 =
+        this._progressHandler0 =
+        this._receiver0 =
+        this._promise0 = undefined;
+    } else {
+        var base = index * 5 - 5;
+        this[base + 3] =
+        this[base + 4] =
+        this[base + 0] =
+        this[base + 1] =
+        this[base + 2] = undefined;
+    }
+};
+
+Promise.prototype._isSettlePromisesQueued = function () {
+    return (this._bitField &
+            -1073741824) === -1073741824;
+};
+
+Promise.prototype._setSettlePromisesQueued = function () {
+    this._bitField = this._bitField | -1073741824;
+};
+
+Promise.prototype._unsetSettlePromisesQueued = function () {
+    this._bitField = this._bitField & (~-1073741824);
+};
+
+Promise.prototype._queueSettlePromises = function() {
+    async.settlePromises(this);
+    this._setSettlePromisesQueued();
+};
+
+Promise.prototype._fulfillUnchecked = function (value) {
+    if (value === this) {
+        var err = makeSelfResolutionError();
+        this._attachExtraTrace(err);
+        return this._rejectUnchecked(err, undefined);
+    }
+    this._setFulfilled();
+    this._settledValue = value;
+    this._cleanValues();
+
+    if (this._length() > 0) {
+        this._queueSettlePromises();
+    }
+};
+
+Promise.prototype._rejectUncheckedCheckError = function (reason) {
+    var trace = util.ensureErrorObject(reason);
+    this._rejectUnchecked(reason, trace === reason ? undefined : trace);
+};
+
+Promise.prototype._rejectUnchecked = function (reason, trace) {
+    if (reason === this) {
+        var err = makeSelfResolutionError();
+        this._attachExtraTrace(err);
+        return this._rejectUnchecked(err);
+    }
+    this._setRejected();
+    this._settledValue = reason;
+    this._cleanValues();
+
+    if (this._isFinal()) {
+        async.throwLater(function(e) {
+            if ("stack" in e) {
+                async.invokeFirst(
+                    CapturedTrace.unhandledRejection, undefined, e);
+            }
+            throw e;
+        }, trace === undefined ? reason : trace);
+        return;
+    }
+
+    if (trace !== undefined && trace !== reason) {
+        this._setCarriedStackTrace(trace);
+    }
+
+    if (this._length() > 0) {
+        this._queueSettlePromises();
+    } else {
+        this._ensurePossibleRejectionHandled();
+    }
+};
+
+Promise.prototype._settlePromises = function () {
+    this._unsetSettlePromisesQueued();
+    var len = this._length();
+    for (var i = 0; i < len; i++) {
+        this._settlePromiseAt(i);
+    }
+};
+
+util.notEnumerableProp(Promise,
+                       "_makeSelfResolutionError",
+                       makeSelfResolutionError);
+
+_dereq_("./progress.js")(Promise, PromiseArray);
+_dereq_("./method.js")(Promise, INTERNAL, tryConvertToPromise, apiRejection);
+_dereq_("./bind.js")(Promise, INTERNAL, tryConvertToPromise);
+_dereq_("./finally.js")(Promise, NEXT_FILTER, tryConvertToPromise);
+_dereq_("./direct_resolve.js")(Promise);
+_dereq_("./synchronous_inspection.js")(Promise);
+_dereq_("./join.js")(Promise, PromiseArray, tryConvertToPromise, INTERNAL);
+Promise.Promise = Promise;
+_dereq_('./map.js')(Promise, PromiseArray, apiRejection, tryConvertToPromise, INTERNAL);
+_dereq_('./cancel.js')(Promise);
+_dereq_('./using.js')(Promise, apiRejection, tryConvertToPromise, createContext);
+_dereq_('./generators.js')(Promise, apiRejection, INTERNAL, tryConvertToPromise);
+_dereq_('./nodeify.js')(Promise);
+_dereq_('./call_get.js')(Promise);
+_dereq_('./props.js')(Promise, PromiseArray, tryConvertToPromise, apiRejection);
+_dereq_('./race.js')(Promise, INTERNAL, tryConvertToPromise, apiRejection);
+_dereq_('./reduce.js')(Promise, PromiseArray, apiRejection, tryConvertToPromise, INTERNAL);
+_dereq_('./settle.js')(Promise, PromiseArray);
+_dereq_('./some.js')(Promise, PromiseArray, apiRejection);
+_dereq_('./promisify.js')(Promise, INTERNAL);
+_dereq_('./any.js')(Promise);
+_dereq_('./each.js')(Promise, INTERNAL);
+_dereq_('./timers.js')(Promise, INTERNAL);
+_dereq_('./filter.js')(Promise, INTERNAL);
+                                                         
+    util.toFastProperties(Promise);                                          
+    util.toFastProperties(Promise.prototype);                                
+    function fillTypes(value) {                                              
+        var p = new Promise(INTERNAL);                                       
+        p._fulfillmentHandler0 = value;                                      
+        p._rejectionHandler0 = value;                                        
+        p._progressHandler0 = value;                                         
+        p._promise0 = value;                                                 
+        p._receiver0 = value;                                                
+        p._settledValue = value;                                             
+    }                                                                        
+    // Complete slack tracking, opt out of field-type tracking and           
+    // stabilize map                                                         
+    fillTypes({a: 1});                                                       
+    fillTypes({b: 2});                                                       
+    fillTypes({c: 3});                                                       
+    fillTypes(1);                                                            
+    fillTypes(function(){});                                                 
+    fillTypes(undefined);                                                    
+    fillTypes(false);                                                        
+    fillTypes(new Promise(INTERNAL));                                        
+    CapturedTrace.setBounds(async.firstLineError, util.lastLineError);       
+    return Promise;                                                          
+
+};
+
+},{"./any.js":1,"./async.js":2,"./bind.js":3,"./call_get.js":5,"./cancel.js":6,"./captured_trace.js":7,"./catch_filter.js":8,"./context.js":9,"./debuggability.js":10,"./direct_resolve.js":11,"./each.js":12,"./errors.js":13,"./filter.js":15,"./finally.js":16,"./generators.js":17,"./join.js":18,"./map.js":19,"./method.js":20,"./nodeify.js":21,"./progress.js":22,"./promise_array.js":24,"./promise_resolver.js":25,"./promisify.js":26,"./props.js":27,"./race.js":29,"./reduce.js":30,"./settle.js":32,"./some.js":33,"./synchronous_inspection.js":34,"./thenables.js":35,"./timers.js":36,"./using.js":37,"./util.js":38}],24:[function(_dereq_,module,exports){
+"use strict";
+module.exports = function(Promise, INTERNAL, tryConvertToPromise,
+    apiRejection) {
+var util = _dereq_("./util.js");
+var isArray = util.isArray;
+
+function toResolutionValue(val) {
+    switch(val) {
+    case -2: return [];
+    case -3: return {};
+    }
+}
+
+function PromiseArray(values) {
+    var promise = this._promise = new Promise(INTERNAL);
+    var parent;
+    if (values instanceof Promise) {
+        parent = values;
+        promise._propagateFrom(parent, 1 | 4);
+    }
+    this._values = values;
+    this._length = 0;
+    this._totalResolved = 0;
+    this._init(undefined, -2);
+}
+PromiseArray.prototype.length = function () {
+    return this._length;
+};
+
+PromiseArray.prototype.promise = function () {
+    return this._promise;
+};
+
+PromiseArray.prototype._init = function init(_, resolveValueIfEmpty) {
+    var values = tryConvertToPromise(this._values, this._promise);
+    if (values instanceof Promise) {
+        values = values._target();
+        this._values = values;
+        if (values._isFulfilled()) {
+            values = values._value();
+            if (!isArray(values)) {
+                var err = new Promise.TypeError("expecting an array, a promise or a thenable\u000a\u000a    See http://goo.gl/s8MMhc\u000a");
+                this.__hardReject__(err);
+                return;
+            }
+        } else if (values._isPending()) {
+            values._then(
+                init,
+                this._reject,
+                undefined,
+                this,
+                resolveValueIfEmpty
+           );
+            return;
+        } else {
+            this._reject(values._reason());
+            return;
+        }
+    } else if (!isArray(values)) {
+        this._promise._reject(apiRejection("expecting an array, a promise or a thenable\u000a\u000a    See http://goo.gl/s8MMhc\u000a")._reason());
+        return;
+    }
+
+    if (values.length === 0) {
+        if (resolveValueIfEmpty === -5) {
+            this._resolveEmptyArray();
+        }
+        else {
+            this._resolve(toResolutionValue(resolveValueIfEmpty));
+        }
+        return;
+    }
+    var len = this.getActualLength(values.length);
+    this._length = len;
+    this._values = this.shouldCopyValues() ? new Array(len) : this._values;
+    var promise = this._promise;
+    for (var i = 0; i < len; ++i) {
+        var isResolved = this._isResolved();
+        var maybePromise = tryConvertToPromise(values[i], promise);
+        if (maybePromise instanceof Promise) {
+            maybePromise = maybePromise._target();
+            if (isResolved) {
+                maybePromise._ignoreRejections();
+            } else if (maybePromise._isPending()) {
+                maybePromise._proxyPromiseArray(this, i);
+            } else if (maybePromise._isFulfilled()) {
+                this._promiseFulfilled(maybePromise._value(), i);
+            } else {
+                this._promiseRejected(maybePromise._reason(), i);
+            }
+        } else if (!isResolved) {
+            this._promiseFulfilled(maybePromise, i);
+        }
+    }
+};
+
+PromiseArray.prototype._isResolved = function () {
+    return this._values === null;
+};
+
+PromiseArray.prototype._resolve = function (value) {
+    this._values = null;
+    this._promise._fulfill(value);
+};
+
+PromiseArray.prototype.__hardReject__ =
+PromiseArray.prototype._reject = function (reason) {
+    this._values = null;
+    this._promise._rejectCallback(reason, false, true);
+};
+
+PromiseArray.prototype._promiseProgressed = function (progressValue, index) {
+    this._promise._progress({
+        index: index,
+        value: progressValue
+    });
+};
+
+
+PromiseArray.prototype._promiseFulfilled = function (value, index) {
+    this._values[index] = value;
+    var totalResolved = ++this._totalResolved;
+    if (totalResolved >= this._length) {
+        this._resolve(this._values);
+    }
+};
+
+PromiseArray.prototype._promiseRejected = function (reason, index) {
+    this._totalResolved++;
+    this._reject(reason);
+};
+
+PromiseArray.prototype.shouldCopyValues = function () {
+    return true;
+};
+
+PromiseArray.prototype.getActualLength = function (len) {
+    return len;
+};
+
+return PromiseArray;
+};
+
+},{"./util.js":38}],25:[function(_dereq_,module,exports){
+"use strict";
+var util = _dereq_("./util.js");
+var maybeWrapAsError = util.maybeWrapAsError;
+var errors = _dereq_("./errors.js");
+var TimeoutError = errors.TimeoutError;
+var OperationalError = errors.OperationalError;
+var haveGetters = util.haveGetters;
+var es5 = _dereq_("./es5.js");
+
+function isUntypedError(obj) {
+    return obj instanceof Error &&
+        es5.getPrototypeOf(obj) === Error.prototype;
+}
+
+var rErrorKey = /^(?:name|message|stack|cause)$/;
+function wrapAsOperationalError(obj) {
+    var ret;
+    if (isUntypedError(obj)) {
+        ret = new OperationalError(obj);
+        ret.name = obj.name;
+        ret.message = obj.message;
+        ret.stack = obj.stack;
+        var keys = es5.keys(obj);
+        for (var i = 0; i < keys.length; ++i) {
+            var key = keys[i];
+            if (!rErrorKey.test(key)) {
+                ret[key] = obj[key];
+            }
+        }
+        return ret;
+    }
+    util.markAsOriginatingFromRejection(obj);
+    return obj;
+}
+
+function nodebackForPromise(promise) {
+    return function(err, value) {
+        if (promise === null) return;
+
+        if (err) {
+            var wrapped = wrapAsOperationalError(maybeWrapAsError(err));
+            promise._attachExtraTrace(wrapped);
+            promise._reject(wrapped);
+        } else if (arguments.length > 2) {
+            var $_len = arguments.length;var args = new Array($_len - 1); for(var $_i = 1; $_i < $_len; ++$_i) {args[$_i - 1] = arguments[$_i];}
+            promise._fulfill(args);
+        } else {
+            promise._fulfill(value);
+        }
+
+        promise = null;
+    };
+}
+
+
+var PromiseResolver;
+if (!haveGetters) {
+    PromiseResolver = function (promise) {
+        this.promise = promise;
+        this.asCallback = nodebackForPromise(promise);
+        this.callback = this.asCallback;
+    };
+}
+else {
+    PromiseResolver = function (promise) {
+        this.promise = promise;
+    };
+}
+if (haveGetters) {
+    var prop = {
+        get: function() {
+            return nodebackForPromise(this.promise);
+        }
+    };
+    es5.defineProperty(PromiseResolver.prototype, "asCallback", prop);
+    es5.defineProperty(PromiseResolver.prototype, "callback", prop);
+}
+
+PromiseResolver._nodebackForPromise = nodebackForPromise;
+
+PromiseResolver.prototype.toString = function () {
+    return "[object PromiseResolver]";
+};
+
+PromiseResolver.prototype.resolve =
+PromiseResolver.prototype.fulfill = function (value) {
+    if (!(this instanceof PromiseResolver)) {
+        throw new TypeError("Illegal invocation, resolver resolve/reject must be called within a resolver context. Consider using the promise constructor instead.\u000a\u000a    See http://goo.gl/sdkXL9\u000a");
+    }
+    this.promise._resolveCallback(value);
+};
+
+PromiseResolver.prototype.reject = function (reason) {
+    if (!(this instanceof PromiseResolver)) {
+        throw new TypeError("Illegal invocation, resolver resolve/reject must be called within a resolver context. Consider using the promise constructor instead.\u000a\u000a    See http://goo.gl/sdkXL9\u000a");
+    }
+    this.promise._rejectCallback(reason);
+};
+
+PromiseResolver.prototype.progress = function (value) {
+    if (!(this instanceof PromiseResolver)) {
+        throw new TypeError("Illegal invocation, resolver resolve/reject must be called within a resolver context. Consider using the promise constructor instead.\u000a\u000a    See http://goo.gl/sdkXL9\u000a");
+    }
+    this.promise._progress(value);
+};
+
+PromiseResolver.prototype.cancel = function (err) {
+    this.promise.cancel(err);
+};
+
+PromiseResolver.prototype.timeout = function () {
+    this.reject(new TimeoutError("timeout"));
+};
+
+PromiseResolver.prototype.isResolved = function () {
+    return this.promise.isResolved();
+};
+
+PromiseResolver.prototype.toJSON = function () {
+    return this.promise.toJSON();
+};
+
+module.exports = PromiseResolver;
+
+},{"./errors.js":13,"./es5.js":14,"./util.js":38}],26:[function(_dereq_,module,exports){
+"use strict";
+module.exports = function(Promise, INTERNAL) {
+var THIS = {};
+var util = _dereq_("./util.js");
+var nodebackForPromise = _dereq_("./promise_resolver.js")
+    ._nodebackForPromise;
+var withAppended = util.withAppended;
+var maybeWrapAsError = util.maybeWrapAsError;
+var canEvaluate = util.canEvaluate;
+var TypeError = _dereq_("./errors").TypeError;
+var defaultSuffix = "Async";
+var defaultPromisified = {__isPromisified__: true};
+var noCopyProps = [
+    "arity",    "length",
+    "name",
+    "arguments",
+    "caller",
+    "callee",
+    "prototype",
+    "__isPromisified__"
+];
+var noCopyPropsPattern = new RegExp("^(?:" + noCopyProps.join("|") + ")$");
+
+var defaultFilter = function(name) {
+    return util.isIdentifier(name) &&
+        name.charAt(0) !== "_" &&
+        name !== "constructor";
+};
+
+function propsFilter(key) {
+    return !noCopyPropsPattern.test(key);
+}
+
+function isPromisified(fn) {
+    try {
+        return fn.__isPromisified__ === true;
+    }
+    catch (e) {
+        return false;
+    }
+}
+
+function hasPromisified(obj, key, suffix) {
+    var val = util.getDataPropertyOrDefault(obj, key + suffix,
+                                            defaultPromisified);
+    return val ? isPromisified(val) : false;
+}
+function checkValid(ret, suffix, suffixRegexp) {
+    for (var i = 0; i < ret.length; i += 2) {
+        var key = ret[i];
+        if (suffixRegexp.test(key)) {
+            var keyWithoutAsyncSuffix = key.replace(suffixRegexp, "");
+            for (var j = 0; j < ret.length; j += 2) {
+                if (ret[j] === keyWithoutAsyncSuffix) {
+                    throw new TypeError("Cannot promisify an API that has normal methods with '%s'-suffix\u000a\u000a    See http://goo.gl/iWrZbw\u000a"
+                        .replace("%s", suffix));
+                }
+            }
+        }
+    }
+}
+
+function promisifiableMethods(obj, suffix, suffixRegexp, filter) {
+    var keys = util.inheritedDataKeys(obj);
+    var ret = [];
+    for (var i = 0; i < keys.length; ++i) {
+        var key = keys[i];
+        var value = obj[key];
+        var passesDefaultFilter = filter === defaultFilter
+            ? true : defaultFilter(key, value, obj);
+        if (typeof value === "function" &&
+            !isPromisified(value) &&
+            !hasPromisified(obj, key, suffix) &&
+            filter(key, value, obj, passesDefaultFilter)) {
+            ret.push(key, value);
+        }
+    }
+    checkValid(ret, suffix, suffixRegexp);
+    return ret;
+}
+
+var escapeIdentRegex = function(str) {
+    return str.replace(/([$])/, "\\$");
+};
+
+var makeNodePromisifiedEval;
+if (!true) {
+var switchCaseArgumentOrder = function(likelyArgumentCount) {
+    var ret = [likelyArgumentCount];
+    var min = Math.max(0, likelyArgumentCount - 1 - 3);
+    for(var i = likelyArgumentCount - 1; i >= min; --i) {
+        ret.push(i);
+    }
+    for(var i = likelyArgumentCount + 1; i <= 3; ++i) {
+        ret.push(i);
+    }
+    return ret;
+};
+
+var argumentSequence = function(argumentCount) {
+    return util.filledRange(argumentCount, "_arg", "");
+};
+
+var parameterDeclaration = function(parameterCount) {
+    return util.filledRange(
+        Math.max(parameterCount, 3), "_arg", "");
+};
+
+var parameterCount = function(fn) {
+    if (typeof fn.length === "number") {
+        return Math.max(Math.min(fn.length, 1023 + 1), 0);
+    }
+    return 0;
+};
+
+makeNodePromisifiedEval =
+function(callback, receiver, originalName, fn) {
+    var newParameterCount = Math.max(0, parameterCount(fn) - 1);
+    var argumentOrder = switchCaseArgumentOrder(newParameterCount);
+    var shouldProxyThis = typeof callback === "string" || receiver === THIS;
+
+    function generateCallForArgumentCount(count) {
+        var args = argumentSequence(count).join(", ");
+        var comma = count > 0 ? ", " : "";
+        var ret;
+        if (shouldProxyThis) {
+            ret = "ret = callback.call(this, {{args}}, nodeback); break;\n";
+        } else {
+            ret = receiver === undefined
+                ? "ret = callback({{args}}, nodeback); break;\n"
+                : "ret = callback.call(receiver, {{args}}, nodeback); break;\n";
+        }
+        return ret.replace("{{args}}", args).replace(", ", comma);
+    }
+
+    function generateArgumentSwitchCase() {
+        var ret = "";
+        for (var i = 0; i < argumentOrder.length; ++i) {
+            ret += "case " + argumentOrder[i] +":" +
+                generateCallForArgumentCount(argumentOrder[i]);
+        }
+
+        ret += "                                                             \n\
+        default:                                                             \n\
+            var args = new Array(len + 1);                                   \n\
+            var i = 0;                                                       \n\
+            for (var i = 0; i < len; ++i) {                                  \n\
+               args[i] = arguments[i];                                       \n\
+            }                                                                \n\
+            args[i] = nodeback;                                              \n\
+            [CodeForCall]                                                    \n\
+            break;                                                           \n\
+        ".replace("[CodeForCall]", (shouldProxyThis
+                                ? "ret = callback.apply(this, args);\n"
+                                : "ret = callback.apply(receiver, args);\n"));
+        return ret;
+    }
+
+    var getFunctionCode = typeof callback === "string"
+                                ? ("this != null ? this['"+callback+"'] : fn")
+                                : "fn";
+
+    return new Function("Promise",
+                        "fn",
+                        "receiver",
+                        "withAppended",
+                        "maybeWrapAsError",
+                        "nodebackForPromise",
+                        "tryCatch",
+                        "errorObj",
+                        "notEnumerableProp",
+                        "INTERNAL","'use strict';                            \n\
+        var ret = function (Parameters) {                                    \n\
+            'use strict';                                                    \n\
+            var len = arguments.length;                                      \n\
+            var promise = new Promise(INTERNAL);                             \n\
+            promise._captureStackTrace();                                    \n\
+            var nodeback = nodebackForPromise(promise);                      \n\
+            var ret;                                                         \n\
+            var callback = tryCatch([GetFunctionCode]);                      \n\
+            switch(len) {                                                    \n\
+                [CodeForSwitchCase]                                          \n\
+            }                                                                \n\
+            if (ret === errorObj) {                                          \n\
+                promise._rejectCallback(maybeWrapAsError(ret.e), true, true);\n\
+            }                                                                \n\
+            return promise;                                                  \n\
+        };                                                                   \n\
+        notEnumerableProp(ret, '__isPromisified__', true);                   \n\
+        return ret;                                                          \n\
+        "
+        .replace("Parameters", parameterDeclaration(newParameterCount))
+        .replace("[CodeForSwitchCase]", generateArgumentSwitchCase())
+        .replace("[GetFunctionCode]", getFunctionCode))(
+            Promise,
+            fn,
+            receiver,
+            withAppended,
+            maybeWrapAsError,
+            nodebackForPromise,
+            util.tryCatch,
+            util.errorObj,
+            util.notEnumerableProp,
+            INTERNAL
+        );
+};
+}
+
+function makeNodePromisifiedClosure(callback, receiver, _, fn) {
+    var defaultThis = (function() {return this;})();
+    var method = callback;
+    if (typeof method === "string") {
+        callback = fn;
+    }
+    function promisified() {
+        var _receiver = receiver;
+        if (receiver === THIS) _receiver = this;
+        var promise = new Promise(INTERNAL);
+        promise._captureStackTrace();
+        var cb = typeof method === "string" && this !== defaultThis
+            ? this[method] : callback;
+        var fn = nodebackForPromise(promise);
+        try {
+            cb.apply(_receiver, withAppended(arguments, fn));
+        } catch(e) {
+            promise._rejectCallback(maybeWrapAsError(e), true, true);
+        }
+        return promise;
+    }
+    util.notEnumerableProp(promisified, "__isPromisified__", true);
+    return promisified;
+}
+
+var makeNodePromisified = canEvaluate
+    ? makeNodePromisifiedEval
+    : makeNodePromisifiedClosure;
+
+function promisifyAll(obj, suffix, filter, promisifier) {
+    var suffixRegexp = new RegExp(escapeIdentRegex(suffix) + "$");
+    var methods =
+        promisifiableMethods(obj, suffix, suffixRegexp, filter);
+
+    for (var i = 0, len = methods.length; i < len; i+= 2) {
+        var key = methods[i];
+        var fn = methods[i+1];
+        var promisifiedKey = key + suffix;
+        obj[promisifiedKey] = promisifier === makeNodePromisified
+                ? makeNodePromisified(key, THIS, key, fn, suffix)
+                : promisifier(fn, function() {
+                    return makeNodePromisified(key, THIS, key, fn, suffix);
+                });
+    }
+    util.toFastProperties(obj);
+    return obj;
+}
+
+function promisify(callback, receiver) {
+    return makeNodePromisified(callback, receiver, undefined, callback);
+}
+
+Promise.promisify = function (fn, receiver) {
+    if (typeof fn !== "function") {
+        throw new TypeError("fn must be a function\u000a\u000a    See http://goo.gl/916lJJ\u000a");
+    }
+    if (isPromisified(fn)) {
+        return fn;
+    }
+    var ret = promisify(fn, arguments.length < 2 ? THIS : receiver);
+    util.copyDescriptors(fn, ret, propsFilter);
+    return ret;
+};
+
+Promise.promisifyAll = function (target, options) {
+    if (typeof target !== "function" && typeof target !== "object") {
+        throw new TypeError("the target of promisifyAll must be an object or a function\u000a\u000a    See http://goo.gl/9ITlV0\u000a");
+    }
+    options = Object(options);
+    var suffix = options.suffix;
+    if (typeof suffix !== "string") suffix = defaultSuffix;
+    var filter = options.filter;
+    if (typeof filter !== "function") filter = defaultFilter;
+    var promisifier = options.promisifier;
+    if (typeof promisifier !== "function") promisifier = makeNodePromisified;
+
+    if (!util.isIdentifier(suffix)) {
+        throw new RangeError("suffix must be a valid identifier\u000a\u000a    See http://goo.gl/8FZo5V\u000a");
+    }
+
+    var keys = util.inheritedDataKeys(target);
+    for (var i = 0; i < keys.length; ++i) {
+        var value = target[keys[i]];
+        if (keys[i] !== "constructor" &&
+            util.isClass(value)) {
+            promisifyAll(value.prototype, suffix, filter, promisifier);
+            promisifyAll(value, suffix, filter, promisifier);
+        }
+    }
+
+    return promisifyAll(target, suffix, filter, promisifier);
+};
+};
+
+
+},{"./errors":13,"./promise_resolver.js":25,"./util.js":38}],27:[function(_dereq_,module,exports){
+"use strict";
+module.exports = function(
+    Promise, PromiseArray, tryConvertToPromise, apiRejection) {
+var util = _dereq_("./util.js");
+var isObject = util.isObject;
+var es5 = _dereq_("./es5.js");
+
+function PropertiesPromiseArray(obj) {
+    var keys = es5.keys(obj);
+    var len = keys.length;
+    var values = new Array(len * 2);
+    for (var i = 0; i < len; ++i) {
+        var key = keys[i];
+        values[i] = obj[key];
+        values[i + len] = key;
+    }
+    this.constructor$(values);
+}
+util.inherits(PropertiesPromiseArray, PromiseArray);
+
+PropertiesPromiseArray.prototype._init = function () {
+    this._init$(undefined, -3) ;
+};
+
+PropertiesPromiseArray.prototype._promiseFulfilled = function (value, index) {
+    this._values[index] = value;
+    var totalResolved = ++this._totalResolved;
+    if (totalResolved >= this._length) {
+        var val = {};
+        var keyOffset = this.length();
+        for (var i = 0, len = this.length(); i < len; ++i) {
+            val[this._values[i + keyOffset]] = this._values[i];
+        }
+        this._resolve(val);
+    }
+};
+
+PropertiesPromiseArray.prototype._promiseProgressed = function (value, index) {
+    this._promise._progress({
+        key: this._values[index + this.length()],
+        value: value
+    });
+};
+
+PropertiesPromiseArray.prototype.shouldCopyValues = function () {
+    return false;
+};
+
+PropertiesPromiseArray.prototype.getActualLength = function (len) {
+    return len >> 1;
+};
+
+function props(promises) {
+    var ret;
+    var castValue = tryConvertToPromise(promises);
+
+    if (!isObject(castValue)) {
+        return apiRejection("cannot await properties of a non-object\u000a\u000a    See http://goo.gl/OsFKC8\u000a");
+    } else if (castValue instanceof Promise) {
+        ret = castValue._then(
+            Promise.props, undefined, undefined, undefined, undefined);
+    } else {
+        ret = new PropertiesPromiseArray(castValue).promise();
+    }
+
+    if (castValue instanceof Promise) {
+        ret._propagateFrom(castValue, 4);
+    }
+    return ret;
+}
+
+Promise.prototype.props = function () {
+    return props(this);
+};
+
+Promise.props = function (promises) {
+    return props(promises);
+};
+};
+
+},{"./es5.js":14,"./util.js":38}],28:[function(_dereq_,module,exports){
+"use strict";
+function arrayMove(src, srcIndex, dst, dstIndex, len) {
+    for (var j = 0; j < len; ++j) {
+        dst[j + dstIndex] = src[j + srcIndex];
+        src[j + srcIndex] = void 0;
+    }
+}
+
+function Queue(capacity) {
+    this._capacity = capacity;
+    this._length = 0;
+    this._front = 0;
+}
+
+Queue.prototype._willBeOverCapacity = function (size) {
+    return this._capacity < size;
+};
+
+Queue.prototype._pushOne = function (arg) {
+    var length = this.length();
+    this._checkCapacity(length + 1);
+    var i = (this._front + length) & (this._capacity - 1);
+    this[i] = arg;
+    this._length = length + 1;
+};
+
+Queue.prototype._unshiftOne = function(value) {
+    var capacity = this._capacity;
+    this._checkCapacity(this.length() + 1);
+    var front = this._front;
+    var i = (((( front - 1 ) &
+                    ( capacity - 1) ) ^ capacity ) - capacity );
+    this[i] = value;
+    this._front = i;
+    this._length = this.length() + 1;
+};
+
+Queue.prototype.unshift = function(fn, receiver, arg) {
+    this._unshiftOne(arg);
+    this._unshiftOne(receiver);
+    this._unshiftOne(fn);
+};
+
+Queue.prototype.push = function (fn, receiver, arg) {
+    var length = this.length() + 3;
+    if (this._willBeOverCapacity(length)) {
+        this._pushOne(fn);
+        this._pushOne(receiver);
+        this._pushOne(arg);
+        return;
+    }
+    var j = this._front + length - 3;
+    this._checkCapacity(length);
+    var wrapMask = this._capacity - 1;
+    this[(j + 0) & wrapMask] = fn;
+    this[(j + 1) & wrapMask] = receiver;
+    this[(j + 2) & wrapMask] = arg;
+    this._length = length;
+};
+
+Queue.prototype.shift = function () {
+    var front = this._front,
+        ret = this[front];
+
+    this[front] = undefined;
+    this._front = (front + 1) & (this._capacity - 1);
+    this._length--;
+    return ret;
+};
+
+Queue.prototype.length = function () {
+    return this._length;
+};
+
+Queue.prototype._checkCapacity = function (size) {
+    if (this._capacity < size) {
+        this._resizeTo(this._capacity << 1);
+    }
+};
+
+Queue.prototype._resizeTo = function (capacity) {
+    var oldCapacity = this._capacity;
+    this._capacity = capacity;
+    var front = this._front;
+    var length = this._length;
+    var moveItemsCount = (front + length) & (oldCapacity - 1);
+    arrayMove(this, 0, this, oldCapacity, moveItemsCount);
+};
+
+module.exports = Queue;
+
+},{}],29:[function(_dereq_,module,exports){
+"use strict";
+module.exports = function(
+    Promise, INTERNAL, tryConvertToPromise, apiRejection) {
+var isArray = _dereq_("./util.js").isArray;
+
+var raceLater = function (promise) {
+    return promise.then(function(array) {
+        return race(array, promise);
+    });
+};
+
+function race(promises, parent) {
+    var maybePromise = tryConvertToPromise(promises);
+
+    if (maybePromise instanceof Promise) {
+        return raceLater(maybePromise);
+    } else if (!isArray(promises)) {
+        return apiRejection("expecting an array, a promise or a thenable\u000a\u000a    See http://goo.gl/s8MMhc\u000a");
+    }
+
+    var ret = new Promise(INTERNAL);
+    if (parent !== undefined) {
+        ret._propagateFrom(parent, 4 | 1);
+    }
+    var fulfill = ret._fulfill;
+    var reject = ret._reject;
+    for (var i = 0, len = promises.length; i < len; ++i) {
+        var val = promises[i];
+
+        if (val === undefined && !(i in promises)) {
+            continue;
+        }
+
+        Promise.cast(val)._then(fulfill, reject, undefined, ret, null);
+    }
+    return ret;
+}
+
+Promise.race = function (promises) {
+    return race(promises, undefined);
+};
+
+Promise.prototype.race = function () {
+    return race(this, undefined);
+};
+
+};
+
+},{"./util.js":38}],30:[function(_dereq_,module,exports){
+"use strict";
+module.exports = function(Promise,
+                          PromiseArray,
+                          apiRejection,
+                          tryConvertToPromise,
+                          INTERNAL) {
+var getDomain = Promise._getDomain;
+var async = _dereq_("./async.js");
+var util = _dereq_("./util.js");
+var tryCatch = util.tryCatch;
+var errorObj = util.errorObj;
+function ReductionPromiseArray(promises, fn, accum, _each) {
+    this.constructor$(promises);
+    this._promise._captureStackTrace();
+    this._preservedValues = _each === INTERNAL ? [] : null;
+    this._zerothIsAccum = (accum === undefined);
+    this._gotAccum = false;
+    this._reducingIndex = (this._zerothIsAccum ? 1 : 0);
+    this._valuesPhase = undefined;
+    var maybePromise = tryConvertToPromise(accum, this._promise);
+    var rejected = false;
+    var isPromise = maybePromise instanceof Promise;
+    if (isPromise) {
+        maybePromise = maybePromise._target();
+        if (maybePromise._isPending()) {
+            maybePromise._proxyPromiseArray(this, -1);
+        } else if (maybePromise._isFulfilled()) {
+            accum = maybePromise._value();
+            this._gotAccum = true;
+        } else {
+            this._reject(maybePromise._reason());
+            rejected = true;
+        }
+    }
+    if (!(isPromise || this._zerothIsAccum)) this._gotAccum = true;
+    var domain = getDomain();
+    this._callback = domain === null ? fn : domain.bind(fn);
+    this._accum = accum;
+    if (!rejected) async.invoke(init, this, undefined);
+}
+function init() {
+    this._init$(undefined, -5);
+}
+util.inherits(ReductionPromiseArray, PromiseArray);
+
+ReductionPromiseArray.prototype._init = function () {};
+
+ReductionPromiseArray.prototype._resolveEmptyArray = function () {
+    if (this._gotAccum || this._zerothIsAccum) {
+        this._resolve(this._preservedValues !== null
+                        ? [] : this._accum);
+    }
+};
+
+ReductionPromiseArray.prototype._promiseFulfilled = function (value, index) {
+    var values = this._values;
+    values[index] = value;
+    var length = this.length();
+    var preservedValues = this._preservedValues;
+    var isEach = preservedValues !== null;
+    var gotAccum = this._gotAccum;
+    var valuesPhase = this._valuesPhase;
+    var valuesPhaseIndex;
+    if (!valuesPhase) {
+        valuesPhase = this._valuesPhase = new Array(length);
+        for (valuesPhaseIndex=0; valuesPhaseIndex<length; ++valuesPhaseIndex) {
+            valuesPhase[valuesPhaseIndex] = 0;
+        }
+    }
+    valuesPhaseIndex = valuesPhase[index];
+
+    if (index === 0 && this._zerothIsAccum) {
+        this._accum = value;
+        this._gotAccum = gotAccum = true;
+        valuesPhase[index] = ((valuesPhaseIndex === 0)
+            ? 1 : 2);
+    } else if (index === -1) {
+        this._accum = value;
+        this._gotAccum = gotAccum = true;
+    } else {
+        if (valuesPhaseIndex === 0) {
+            valuesPhase[index] = 1;
+        } else {
+            valuesPhase[index] = 2;
+            this._accum = value;
+        }
+    }
+    if (!gotAccum) return;
+
+    var callback = this._callback;
+    var receiver = this._promise._boundValue();
+    var ret;
+
+    for (var i = this._reducingIndex; i < length; ++i) {
+        valuesPhaseIndex = valuesPhase[i];
+        if (valuesPhaseIndex === 2) {
+            this._reducingIndex = i + 1;
+            continue;
+        }
+        if (valuesPhaseIndex !== 1) return;
+        value = values[i];
+        this._promise._pushContext();
+        if (isEach) {
+            preservedValues.push(value);
+            ret = tryCatch(callback).call(receiver, value, i, length);
+        }
+        else {
+            ret = tryCatch(callback)
+                .call(receiver, this._accum, value, i, length);
+        }
+        this._promise._popContext();
+
+        if (ret === errorObj) return this._reject(ret.e);
+
+        var maybePromise = tryConvertToPromise(ret, this._promise);
+        if (maybePromise instanceof Promise) {
+            maybePromise = maybePromise._target();
+            if (maybePromise._isPending()) {
+                valuesPhase[i] = 4;
+                return maybePromise._proxyPromiseArray(this, i);
+            } else if (maybePromise._isFulfilled()) {
+                ret = maybePromise._value();
+            } else {
+                return this._reject(maybePromise._reason());
+            }
+        }
+
+        this._reducingIndex = i + 1;
+        this._accum = ret;
+    }
+
+    this._resolve(isEach ? preservedValues : this._accum);
+};
+
+function reduce(promises, fn, initialValue, _each) {
+    if (typeof fn !== "function") return apiRejection("fn must be a function\u000a\u000a    See http://goo.gl/916lJJ\u000a");
+    var array = new ReductionPromiseArray(promises, fn, initialValue, _each);
+    return array.promise();
+}
+
+Promise.prototype.reduce = function (fn, initialValue) {
+    return reduce(this, fn, initialValue, null);
+};
+
+Promise.reduce = function (promises, fn, initialValue, _each) {
+    return reduce(promises, fn, initialValue, _each);
+};
+};
+
+},{"./async.js":2,"./util.js":38}],31:[function(_dereq_,module,exports){
+"use strict";
+var schedule;
+var util = _dereq_("./util");
+var noAsyncScheduler = function() {
+    throw new Error("No async scheduler available\u000a\u000a    See http://goo.gl/m3OTXk\u000a");
+};
+if (util.isNode && typeof MutationObserver === "undefined") {
+    var GlobalSetImmediate = global.setImmediate;
+    var ProcessNextTick = process.nextTick;
+    schedule = util.isRecentNode
+                ? function(fn) { GlobalSetImmediate.call(global, fn); }
+                : function(fn) { ProcessNextTick.call(process, fn); };
+} else if ((typeof MutationObserver !== "undefined") &&
+          !(typeof window !== "undefined" &&
+            window.navigator &&
+            window.navigator.standalone)) {
+    schedule = function(fn) {
+        var div = document.createElement("div");
+        var observer = new MutationObserver(fn);
+        observer.observe(div, {attributes: true});
+        return function() { div.classList.toggle("foo"); };
+    };
+    schedule.isStatic = true;
+} else if (typeof setImmediate !== "undefined") {
+    schedule = function (fn) {
+        setImmediate(fn);
+    };
+} else if (typeof setTimeout !== "undefined") {
+    schedule = function (fn) {
+        setTimeout(fn, 0);
+    };
+} else {
+    schedule = noAsyncScheduler;
+}
+module.exports = schedule;
+
+},{"./util":38}],32:[function(_dereq_,module,exports){
+"use strict";
+module.exports =
+    function(Promise, PromiseArray) {
+var PromiseInspection = Promise.PromiseInspection;
+var util = _dereq_("./util.js");
+
+function SettledPromiseArray(values) {
+    this.constructor$(values);
+}
+util.inherits(SettledPromiseArray, PromiseArray);
+
+SettledPromiseArray.prototype._promiseResolved = function (index, inspection) {
+    this._values[index] = inspection;
+    var totalResolved = ++this._totalResolved;
+    if (totalResolved >= this._length) {
+        this._resolve(this._values);
+    }
+};
+
+SettledPromiseArray.prototype._promiseFulfilled = function (value, index) {
+    var ret = new PromiseInspection();
+    ret._bitField = 268435456;
+    ret._settledValue = value;
+    this._promiseResolved(index, ret);
+};
+SettledPromiseArray.prototype._promiseRejected = function (reason, index) {
+    var ret = new PromiseInspection();
+    ret._bitField = 134217728;
+    ret._settledValue = reason;
+    this._promiseResolved(index, ret);
+};
+
+Promise.settle = function (promises) {
+    return new SettledPromiseArray(promises).promise();
+};
+
+Promise.prototype.settle = function () {
+    return new SettledPromiseArray(this).promise();
+};
+};
+
+},{"./util.js":38}],33:[function(_dereq_,module,exports){
+"use strict";
+module.exports =
+function(Promise, PromiseArray, apiRejection) {
+var util = _dereq_("./util.js");
+var RangeError = _dereq_("./errors.js").RangeError;
+var AggregateError = _dereq_("./errors.js").AggregateError;
+var isArray = util.isArray;
+
+
+function SomePromiseArray(values) {
+    this.constructor$(values);
+    this._howMany = 0;
+    this._unwrap = false;
+    this._initialized = false;
+}
+util.inherits(SomePromiseArray, PromiseArray);
+
+SomePromiseArray.prototype._init = function () {
+    if (!this._initialized) {
+        return;
+    }
+    if (this._howMany === 0) {
+        this._resolve([]);
+        return;
+    }
+    this._init$(undefined, -5);
+    var isArrayResolved = isArray(this._values);
+    if (!this._isResolved() &&
+        isArrayResolved &&
+        this._howMany > this._canPossiblyFulfill()) {
+        this._reject(this._getRangeError(this.length()));
+    }
+};
+
+SomePromiseArray.prototype.init = function () {
+    this._initialized = true;
+    this._init();
+};
+
+SomePromiseArray.prototype.setUnwrap = function () {
+    this._unwrap = true;
+};
+
+SomePromiseArray.prototype.howMany = function () {
+    return this._howMany;
+};
+
+SomePromiseArray.prototype.setHowMany = function (count) {
+    this._howMany = count;
+};
+
+SomePromiseArray.prototype._promiseFulfilled = function (value) {
+    this._addFulfilled(value);
+    if (this._fulfilled() === this.howMany()) {
+        this._values.length = this.howMany();
+        if (this.howMany() === 1 && this._unwrap) {
+            this._resolve(this._values[0]);
+        } else {
+            this._resolve(this._values);
+        }
+    }
+
+};
+SomePromiseArray.prototype._promiseRejected = function (reason) {
+    this._addRejected(reason);
+    if (this.howMany() > this._canPossiblyFulfill()) {
+        var e = new AggregateError();
+        for (var i = this.length(); i < this._values.length; ++i) {
+            e.push(this._values[i]);
+        }
+        this._reject(e);
+    }
+};
+
+SomePromiseArray.prototype._fulfilled = function () {
+    return this._totalResolved;
+};
+
+SomePromiseArray.prototype._rejected = function () {
+    return this._values.length - this.length();
+};
+
+SomePromiseArray.prototype._addRejected = function (reason) {
+    this._values.push(reason);
+};
+
+SomePromiseArray.prototype._addFulfilled = function (value) {
+    this._values[this._totalResolved++] = value;
+};
+
+SomePromiseArray.prototype._canPossiblyFulfill = function () {
+    return this.length() - this._rejected();
+};
+
+SomePromiseArray.prototype._getRangeError = function (count) {
+    var message = "Input array must contain at least " +
+            this._howMany + " items but contains only " + count + " items";
+    return new RangeError(message);
+};
+
+SomePromiseArray.prototype._resolveEmptyArray = function () {
+    this._reject(this._getRangeError(0));
+};
+
+function some(promises, howMany) {
+    if ((howMany | 0) !== howMany || howMany < 0) {
+        return apiRejection("expecting a positive integer\u000a\u000a    See http://goo.gl/1wAmHx\u000a");
+    }
+    var ret = new SomePromiseArray(promises);
+    var promise = ret.promise();
+    ret.setHowMany(howMany);
+    ret.init();
+    return promise;
+}
+
+Promise.some = function (promises, howMany) {
+    return some(promises, howMany);
+};
+
+Promise.prototype.some = function (howMany) {
+    return some(this, howMany);
+};
+
+Promise._SomePromiseArray = SomePromiseArray;
+};
+
+},{"./errors.js":13,"./util.js":38}],34:[function(_dereq_,module,exports){
+"use strict";
+module.exports = function(Promise) {
+function PromiseInspection(promise) {
+    if (promise !== undefined) {
+        promise = promise._target();
+        this._bitField = promise._bitField;
+        this._settledValue = promise._settledValue;
+    }
+    else {
+        this._bitField = 0;
+        this._settledValue = undefined;
+    }
+}
+
+PromiseInspection.prototype.value = function () {
+    if (!this.isFulfilled()) {
+        throw new TypeError("cannot get fulfillment value of a non-fulfilled promise\u000a\u000a    See http://goo.gl/hc1DLj\u000a");
+    }
+    return this._settledValue;
+};
+
+PromiseInspection.prototype.error =
+PromiseInspection.prototype.reason = function () {
+    if (!this.isRejected()) {
+        throw new TypeError("cannot get rejection reason of a non-rejected promise\u000a\u000a    See http://goo.gl/hPuiwB\u000a");
+    }
+    return this._settledValue;
+};
+
+PromiseInspection.prototype.isFulfilled =
+Promise.prototype._isFulfilled = function () {
+    return (this._bitField & 268435456) > 0;
+};
+
+PromiseInspection.prototype.isRejected =
+Promise.prototype._isRejected = function () {
+    return (this._bitField & 134217728) > 0;
+};
+
+PromiseInspection.prototype.isPending =
+Promise.prototype._isPending = function () {
+    return (this._bitField & 402653184) === 0;
+};
+
+PromiseInspection.prototype.isResolved =
+Promise.prototype._isResolved = function () {
+    return (this._bitField & 402653184) > 0;
+};
+
+Promise.prototype.isPending = function() {
+    return this._target()._isPending();
+};
+
+Promise.prototype.isRejected = function() {
+    return this._target()._isRejected();
+};
+
+Promise.prototype.isFulfilled = function() {
+    return this._target()._isFulfilled();
+};
+
+Promise.prototype.isResolved = function() {
+    return this._target()._isResolved();
+};
+
+Promise.prototype._value = function() {
+    return this._settledValue;
+};
+
+Promise.prototype._reason = function() {
+    this._unsetRejectionIsUnhandled();
+    return this._settledValue;
+};
+
+Promise.prototype.value = function() {
+    var target = this._target();
+    if (!target.isFulfilled()) {
+        throw new TypeError("cannot get fulfillment value of a non-fulfilled promise\u000a\u000a    See http://goo.gl/hc1DLj\u000a");
+    }
+    return target._settledValue;
+};
+
+Promise.prototype.reason = function() {
+    var target = this._target();
+    if (!target.isRejected()) {
+        throw new TypeError("cannot get rejection reason of a non-rejected promise\u000a\u000a    See http://goo.gl/hPuiwB\u000a");
+    }
+    target._unsetRejectionIsUnhandled();
+    return target._settledValue;
+};
+
+
+Promise.PromiseInspection = PromiseInspection;
+};
+
+},{}],35:[function(_dereq_,module,exports){
+"use strict";
+module.exports = function(Promise, INTERNAL) {
+var util = _dereq_("./util.js");
+var errorObj = util.errorObj;
+var isObject = util.isObject;
+
+function tryConvertToPromise(obj, context) {
+    if (isObject(obj)) {
+        if (obj instanceof Promise) {
+            return obj;
+        }
+        else if (isAnyBluebirdPromise(obj)) {
+            var ret = new Promise(INTERNAL);
+            obj._then(
+                ret._fulfillUnchecked,
+                ret._rejectUncheckedCheckError,
+                ret._progressUnchecked,
+                ret,
+                null
+            );
+            return ret;
+        }
+        var then = util.tryCatch(getThen)(obj);
+        if (then === errorObj) {
+            if (context) context._pushContext();
+            var ret = Promise.reject(then.e);
+            if (context) context._popContext();
+            return ret;
+        } else if (typeof then === "function") {
+            return doThenable(obj, then, context);
+        }
+    }
+    return obj;
+}
+
+function getThen(obj) {
+    return obj.then;
+}
+
+var hasProp = {}.hasOwnProperty;
+function isAnyBluebirdPromise(obj) {
+    return hasProp.call(obj, "_promise0");
+}
+
+function doThenable(x, then, context) {
+    var promise = new Promise(INTERNAL);
+    var ret = promise;
+    if (context) context._pushContext();
+    promise._captureStackTrace();
+    if (context) context._popContext();
+    var synchronous = true;
+    var result = util.tryCatch(then).call(x,
+                                        resolveFromThenable,
+                                        rejectFromThenable,
+                                        progressFromThenable);
+    synchronous = false;
+    if (promise && result === errorObj) {
+        promise._rejectCallback(result.e, true, true);
+        promise = null;
+    }
+
+    function resolveFromThenable(value) {
+        if (!promise) return;
+        promise._resolveCallback(value);
+        promise = null;
+    }
+
+    function rejectFromThenable(reason) {
+        if (!promise) return;
+        promise._rejectCallback(reason, synchronous, true);
+        promise = null;
+    }
+
+    function progressFromThenable(value) {
+        if (!promise) return;
+        if (typeof promise._progress === "function") {
+            promise._progress(value);
+        }
+    }
+    return ret;
+}
+
+return tryConvertToPromise;
+};
+
+},{"./util.js":38}],36:[function(_dereq_,module,exports){
+"use strict";
+module.exports = function(Promise, INTERNAL) {
+var util = _dereq_("./util.js");
+var TimeoutError = Promise.TimeoutError;
+
+var afterTimeout = function (promise, message) {
+    if (!promise.isPending()) return;
+    if (typeof message !== "string") {
+        message = "operation timed out";
+    }
+    var err = new TimeoutError(message);
+    util.markAsOriginatingFromRejection(err);
+    promise._attachExtraTrace(err);
+    promise._cancel(err);
+};
+
+var afterValue = function(value) { return delay(+this).thenReturn(value); };
+var delay = Promise.delay = function (value, ms) {
+    if (ms === undefined) {
+        ms = value;
+        value = undefined;
+        var ret = new Promise(INTERNAL);
+        setTimeout(function() { ret._fulfill(); }, ms);
+        return ret;
+    }
+    ms = +ms;
+    return Promise.resolve(value)._then(afterValue, null, null, ms, undefined);
+};
+
+Promise.prototype.delay = function (ms) {
+    return delay(this, ms);
+};
+
+function successClear(value) {
+    var handle = this;
+    if (handle instanceof Number) handle = +handle;
+    clearTimeout(handle);
+    return value;
+}
+
+function failureClear(reason) {
+    var handle = this;
+    if (handle instanceof Number) handle = +handle;
+    clearTimeout(handle);
+    throw reason;
+}
+
+Promise.prototype.timeout = function (ms, message) {
+    ms = +ms;
+    var ret = this.then().cancellable();
+    ret._cancellationParent = this;
+    var handle = setTimeout(function timeoutTimeout() {
+        afterTimeout(ret, message);
+    }, ms);
+    return ret._then(successClear, failureClear, undefined, handle, undefined);
+};
+
+};
+
+},{"./util.js":38}],37:[function(_dereq_,module,exports){
+"use strict";
+module.exports = function (Promise, apiRejection, tryConvertToPromise,
+    createContext) {
+    var TypeError = _dereq_("./errors.js").TypeError;
+    var inherits = _dereq_("./util.js").inherits;
+    var PromiseInspection = Promise.PromiseInspection;
+
+    function inspectionMapper(inspections) {
+        var len = inspections.length;
+        for (var i = 0; i < len; ++i) {
+            var inspection = inspections[i];
+            if (inspection.isRejected()) {
+                return Promise.reject(inspection.error());
+            }
+            inspections[i] = inspection._settledValue;
+        }
+        return inspections;
+    }
+
+    function thrower(e) {
+        setTimeout(function(){throw e;}, 0);
+    }
+
+    function castPreservingDisposable(thenable) {
+        var maybePromise = tryConvertToPromise(thenable);
+        if (maybePromise !== thenable &&
+            typeof thenable._isDisposable === "function" &&
+            typeof thenable._getDisposer === "function" &&
+            thenable._isDisposable()) {
+            maybePromise._setDisposable(thenable._getDisposer());
+        }
+        return maybePromise;
+    }
+    function dispose(resources, inspection) {
+        var i = 0;
+        var len = resources.length;
+        var ret = Promise.defer();
+        function iterator() {
+            if (i >= len) return ret.resolve();
+            var maybePromise = castPreservingDisposable(resources[i++]);
+            if (maybePromise instanceof Promise &&
+                maybePromise._isDisposable()) {
+                try {
+                    maybePromise = tryConvertToPromise(
+                        maybePromise._getDisposer().tryDispose(inspection),
+                        resources.promise);
+                } catch (e) {
+                    return thrower(e);
+                }
+                if (maybePromise instanceof Promise) {
+                    return maybePromise._then(iterator, thrower,
+                                              null, null, null);
+                }
+            }
+            iterator();
+        }
+        iterator();
+        return ret.promise;
+    }
+
+    function disposerSuccess(value) {
+        var inspection = new PromiseInspection();
+        inspection._settledValue = value;
+        inspection._bitField = 268435456;
+        return dispose(this, inspection).thenReturn(value);
+    }
+
+    function disposerFail(reason) {
+        var inspection = new PromiseInspection();
+        inspection._settledValue = reason;
+        inspection._bitField = 134217728;
+        return dispose(this, inspection).thenThrow(reason);
+    }
+
+    function Disposer(data, promise, context) {
+        this._data = data;
+        this._promise = promise;
+        this._context = context;
+    }
+
+    Disposer.prototype.data = function () {
+        return this._data;
+    };
+
+    Disposer.prototype.promise = function () {
+        return this._promise;
+    };
+
+    Disposer.prototype.resource = function () {
+        if (this.promise().isFulfilled()) {
+            return this.promise().value();
+        }
+        return null;
+    };
+
+    Disposer.prototype.tryDispose = function(inspection) {
+        var resource = this.resource();
+        var context = this._context;
+        if (context !== undefined) context._pushContext();
+        var ret = resource !== null
+            ? this.doDispose(resource, inspection) : null;
+        if (context !== undefined) context._popContext();
+        this._promise._unsetDisposable();
+        this._data = null;
+        return ret;
+    };
+
+    Disposer.isDisposer = function (d) {
+        return (d != null &&
+                typeof d.resource === "function" &&
+                typeof d.tryDispose === "function");
+    };
+
+    function FunctionDisposer(fn, promise, context) {
+        this.constructor$(fn, promise, context);
+    }
+    inherits(FunctionDisposer, Disposer);
+
+    FunctionDisposer.prototype.doDispose = function (resource, inspection) {
+        var fn = this.data();
+        return fn.call(resource, resource, inspection);
+    };
+
+    function maybeUnwrapDisposer(value) {
+        if (Disposer.isDisposer(value)) {
+            this.resources[this.index]._setDisposable(value);
+            return value.promise();
+        }
+        return value;
+    }
+
+    Promise.using = function () {
+        var len = arguments.length;
+        if (len < 2) return apiRejection(
+                        "you must pass at least 2 arguments to Promise.using");
+        var fn = arguments[len - 1];
+        if (typeof fn !== "function") return apiRejection("fn must be a function\u000a\u000a    See http://goo.gl/916lJJ\u000a");
+        len--;
+        var resources = new Array(len);
+        for (var i = 0; i < len; ++i) {
+            var resource = arguments[i];
+            if (Disposer.isDisposer(resource)) {
+                var disposer = resource;
+                resource = resource.promise();
+                resource._setDisposable(disposer);
+            } else {
+                var maybePromise = tryConvertToPromise(resource);
+                if (maybePromise instanceof Promise) {
+                    resource =
+                        maybePromise._then(maybeUnwrapDisposer, null, null, {
+                            resources: resources,
+                            index: i
+                    }, undefined);
+                }
+            }
+            resources[i] = resource;
+        }
+
+        var promise = Promise.settle(resources)
+            .then(inspectionMapper)
+            .then(function(vals) {
+                promise._pushContext();
+                var ret;
+                try {
+                    ret = fn.apply(undefined, vals);
+                } finally {
+                    promise._popContext();
+                }
+                return ret;
+            })
+            ._then(
+                disposerSuccess, disposerFail, undefined, resources, undefined);
+        resources.promise = promise;
+        return promise;
+    };
+
+    Promise.prototype._setDisposable = function (disposer) {
+        this._bitField = this._bitField | 262144;
+        this._disposer = disposer;
+    };
+
+    Promise.prototype._isDisposable = function () {
+        return (this._bitField & 262144) > 0;
+    };
+
+    Promise.prototype._getDisposer = function () {
+        return this._disposer;
+    };
+
+    Promise.prototype._unsetDisposable = function () {
+        this._bitField = this._bitField & (~262144);
+        this._disposer = undefined;
+    };
+
+    Promise.prototype.disposer = function (fn) {
+        if (typeof fn === "function") {
+            return new FunctionDisposer(fn, this, createContext());
+        }
+        throw new TypeError();
+    };
+
+};
+
+},{"./errors.js":13,"./util.js":38}],38:[function(_dereq_,module,exports){
+"use strict";
+var es5 = _dereq_("./es5.js");
+var canEvaluate = typeof navigator == "undefined";
+var haveGetters = (function(){
+    try {
+        var o = {};
+        es5.defineProperty(o, "f", {
+            get: function () {
+                return 3;
+            }
+        });
+        return o.f === 3;
+    }
+    catch (e) {
+        return false;
+    }
+
+})();
+
+var errorObj = {e: {}};
+var tryCatchTarget;
+function tryCatcher() {
+    try {
+        var target = tryCatchTarget;
+        tryCatchTarget = null;
+        return target.apply(this, arguments);
+    } catch (e) {
+        errorObj.e = e;
+        return errorObj;
+    }
+}
+function tryCatch(fn) {
+    tryCatchTarget = fn;
+    return tryCatcher;
+}
+
+var inherits = function(Child, Parent) {
+    var hasProp = {}.hasOwnProperty;
+
+    function T() {
+        this.constructor = Child;
+        this.constructor$ = Parent;
+        for (var propertyName in Parent.prototype) {
+            if (hasProp.call(Parent.prototype, propertyName) &&
+                propertyName.charAt(propertyName.length-1) !== "$"
+           ) {
+                this[propertyName + "$"] = Parent.prototype[propertyName];
+            }
+        }
+    }
+    T.prototype = Parent.prototype;
+    Child.prototype = new T();
+    return Child.prototype;
+};
+
+
+function isPrimitive(val) {
+    return val == null || val === true || val === false ||
+        typeof val === "string" || typeof val === "number";
+
+}
+
+function isObject(value) {
+    return !isPrimitive(value);
+}
+
+function maybeWrapAsError(maybeError) {
+    if (!isPrimitive(maybeError)) return maybeError;
+
+    return new Error(safeToString(maybeError));
+}
+
+function withAppended(target, appendee) {
+    var len = target.length;
+    var ret = new Array(len + 1);
+    var i;
+    for (i = 0; i < len; ++i) {
+        ret[i] = target[i];
+    }
+    ret[i] = appendee;
+    return ret;
+}
+
+function getDataPropertyOrDefault(obj, key, defaultValue) {
+    if (es5.isES5) {
+        var desc = Object.getOwnPropertyDescriptor(obj, key);
+
+        if (desc != null) {
+            return desc.get == null && desc.set == null
+                    ? desc.value
+                    : defaultValue;
+        }
+    } else {
+        return {}.hasOwnProperty.call(obj, key) ? obj[key] : undefined;
+    }
+}
+
+function notEnumerableProp(obj, name, value) {
+    if (isPrimitive(obj)) return obj;
+    var descriptor = {
+        value: value,
+        configurable: true,
+        enumerable: false,
+        writable: true
+    };
+    es5.defineProperty(obj, name, descriptor);
+    return obj;
+}
+
+function thrower(r) {
+    throw r;
+}
+
+var inheritedDataKeys = (function() {
+    var excludedPrototypes = [
+        Array.prototype,
+        Object.prototype,
+        Function.prototype
+    ];
+
+    var isExcludedProto = function(val) {
+        for (var i = 0; i < excludedPrototypes.length; ++i) {
+            if (excludedPrototypes[i] === val) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    if (es5.isES5) {
+        var getKeys = Object.getOwnPropertyNames;
+        return function(obj) {
+            var ret = [];
+            var visitedKeys = Object.create(null);
+            while (obj != null && !isExcludedProto(obj)) {
+                var keys;
+                try {
+                    keys = getKeys(obj);
+                } catch (e) {
+                    return ret;
+                }
+                for (var i = 0; i < keys.length; ++i) {
+                    var key = keys[i];
+                    if (visitedKeys[key]) continue;
+                    visitedKeys[key] = true;
+                    var desc = Object.getOwnPropertyDescriptor(obj, key);
+                    if (desc != null && desc.get == null && desc.set == null) {
+                        ret.push(key);
+                    }
+                }
+                obj = es5.getPrototypeOf(obj);
+            }
+            return ret;
+        };
+    } else {
+        var hasProp = {}.hasOwnProperty;
+        return function(obj) {
+            if (isExcludedProto(obj)) return [];
+            var ret = [];
+
+            /*jshint forin:false */
+            enumeration: for (var key in obj) {
+                if (hasProp.call(obj, key)) {
+                    ret.push(key);
+                } else {
+                    for (var i = 0; i < excludedPrototypes.length; ++i) {
+                        if (hasProp.call(excludedPrototypes[i], key)) {
+                            continue enumeration;
+                        }
+                    }
+                    ret.push(key);
+                }
+            }
+            return ret;
+        };
+    }
+
+})();
+
+var thisAssignmentPattern = /this\s*\.\s*\S+\s*=/;
+function isClass(fn) {
+    try {
+        if (typeof fn === "function") {
+            var keys = es5.names(fn.prototype);
+
+            var hasMethods = es5.isES5 && keys.length > 1;
+            var hasMethodsOtherThanConstructor = keys.length > 0 &&
+                !(keys.length === 1 && keys[0] === "constructor");
+            var hasThisAssignmentAndStaticMethods =
+                thisAssignmentPattern.test(fn + "") && es5.names(fn).length > 0;
+
+            if (hasMethods || hasMethodsOtherThanConstructor ||
+                hasThisAssignmentAndStaticMethods) {
+                return true;
+            }
+        }
+        return false;
+    } catch (e) {
+        return false;
+    }
+}
+
+function toFastProperties(obj) {
+    /*jshint -W027,-W055,-W031*/
+    function f() {}
+    f.prototype = obj;
+    var l = 8;
+    while (l--) new f();
+    return obj;
+    eval(obj);
+}
+
+var rident = /^[a-z$_][a-z$_0-9]*$/i;
+function isIdentifier(str) {
+    return rident.test(str);
+}
+
+function filledRange(count, prefix, suffix) {
+    var ret = new Array(count);
+    for(var i = 0; i < count; ++i) {
+        ret[i] = prefix + i + suffix;
+    }
+    return ret;
+}
+
+function safeToString(obj) {
+    try {
+        return obj + "";
+    } catch (e) {
+        return "[no string representation]";
+    }
+}
+
+function markAsOriginatingFromRejection(e) {
+    try {
+        notEnumerableProp(e, "isOperational", true);
+    }
+    catch(ignore) {}
+}
+
+function originatesFromRejection(e) {
+    if (e == null) return false;
+    return ((e instanceof Error["__BluebirdErrorTypes__"].OperationalError) ||
+        e["isOperational"] === true);
+}
+
+function canAttachTrace(obj) {
+    return obj instanceof Error && es5.propertyIsWritable(obj, "stack");
+}
+
+var ensureErrorObject = (function() {
+    if (!("stack" in new Error())) {
+        return function(value) {
+            if (canAttachTrace(value)) return value;
+            try {throw new Error(safeToString(value));}
+            catch(err) {return err;}
+        };
+    } else {
+        return function(value) {
+            if (canAttachTrace(value)) return value;
+            return new Error(safeToString(value));
+        };
+    }
+})();
+
+function classString(obj) {
+    return {}.toString.call(obj);
+}
+
+function copyDescriptors(from, to, filter) {
+    var keys = es5.names(from);
+    for (var i = 0; i < keys.length; ++i) {
+        var key = keys[i];
+        if (filter(key)) {
+            try {
+                es5.defineProperty(to, key, es5.getDescriptor(from, key));
+            } catch (ignore) {}
+        }
+    }
+}
+
+var ret = {
+    isClass: isClass,
+    isIdentifier: isIdentifier,
+    inheritedDataKeys: inheritedDataKeys,
+    getDataPropertyOrDefault: getDataPropertyOrDefault,
+    thrower: thrower,
+    isArray: es5.isArray,
+    haveGetters: haveGetters,
+    notEnumerableProp: notEnumerableProp,
+    isPrimitive: isPrimitive,
+    isObject: isObject,
+    canEvaluate: canEvaluate,
+    errorObj: errorObj,
+    tryCatch: tryCatch,
+    inherits: inherits,
+    withAppended: withAppended,
+    maybeWrapAsError: maybeWrapAsError,
+    toFastProperties: toFastProperties,
+    filledRange: filledRange,
+    toString: safeToString,
+    canAttachTrace: canAttachTrace,
+    ensureErrorObject: ensureErrorObject,
+    originatesFromRejection: originatesFromRejection,
+    markAsOriginatingFromRejection: markAsOriginatingFromRejection,
+    classString: classString,
+    copyDescriptors: copyDescriptors,
+    hasDevTools: typeof chrome !== "undefined" && chrome &&
+                 typeof chrome.loadTimes === "function",
+    isNode: typeof process !== "undefined" &&
+        classString(process).toLowerCase() === "[object process]"
+};
+ret.isRecentNode = ret.isNode && (function() {
+    var version = process.versions.node.split(".").map(Number);
+    return (version[0] === 0 && version[1] > 10) || (version[0] > 0);
+})();
+
+if (ret.isNode) ret.toFastProperties(process);
+
+try {throw new Error(); } catch (e) {ret.lastLineError = e;}
+module.exports = ret;
+
+},{"./es5.js":14}]},{},[4])(4)
+});                    ;if (typeof window !== 'undefined' && window !== null) {                               window.P = window.Promise;                                                     } else if (typeof self !== 'undefined' && self !== null) {                             self.P = self.Promise;                                                         }
+}).call(this,require(23),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+},{}],19:[function(require,module,exports){
+/*!
+ * The buffer module from node.js, for the browser.
+ *
+ * @author   Feross Aboukhadijeh <feross@feross.org> <http://feross.org>
+ * @license  MIT
+ */
+
+var base64 = require(20)
+var ieee754 = require(21)
+var isArray = require(22)
+
+exports.Buffer = Buffer
+exports.SlowBuffer = Buffer
+exports.INSPECT_MAX_BYTES = 50
+Buffer.poolSize = 8192 // not used by this implementation
+
+var kMaxLength = 0x3fffffff
+
+/**
+ * If `Buffer.TYPED_ARRAY_SUPPORT`:
+ *   === true    Use Uint8Array implementation (fastest)
+ *   === false   Use Object implementation (most compatible, even IE6)
+ *
+ * Browsers that support typed arrays are IE 10+, Firefox 4+, Chrome 7+, Safari 5.1+,
+ * Opera 11.6+, iOS 4.2+.
+ *
+ * Note:
+ *
+ * - Implementation must support adding new properties to `Uint8Array` instances.
+ *   Firefox 4-29 lacked support, fixed in Firefox 30+.
+ *   See: https://bugzilla.mozilla.org/show_bug.cgi?id=695438.
+ *
+ *  - Chrome 9-10 is missing the `TypedArray.prototype.subarray` function.
+ *
+ *  - IE10 has a broken `TypedArray.prototype.subarray` function which returns arrays of
+ *    incorrect length in some situations.
+ *
+ * We detect these buggy browsers and set `Buffer.TYPED_ARRAY_SUPPORT` to `false` so they will
+ * get the Object implementation, which is slower but will work correctly.
+ */
+Buffer.TYPED_ARRAY_SUPPORT = (function () {
+  try {
+    var buf = new ArrayBuffer(0)
+    var arr = new Uint8Array(buf)
+    arr.foo = function () { return 42 }
+    return 42 === arr.foo() && // typed array instances can be augmented
+        typeof arr.subarray === 'function' && // chrome 9-10 lack `subarray`
+        new Uint8Array(1).subarray(1, 1).byteLength === 0 // ie10 has broken `subarray`
+  } catch (e) {
+    return false
+  }
+})()
+
+/**
+ * Class: Buffer
+ * =============
+ *
+ * The Buffer constructor returns instances of `Uint8Array` that are augmented
+ * with function properties for all the node `Buffer` API functions. We use
+ * `Uint8Array` so that square bracket notation works as expected -- it returns
+ * a single octet.
+ *
+ * By augmenting the instances, we can avoid modifying the `Uint8Array`
+ * prototype.
+ */
+function Buffer (subject, encoding, noZero) {
+  if (!(this instanceof Buffer))
+    return new Buffer(subject, encoding, noZero)
+
+  var type = typeof subject
+
+  // Find the length
+  var length
+  if (type === 'number')
+    length = subject > 0 ? subject >>> 0 : 0
+  else if (type === 'string') {
+    if (encoding === 'base64')
+      subject = base64clean(subject)
+    length = Buffer.byteLength(subject, encoding)
+  } else if (type === 'object' && subject !== null) { // assume object is array-like
+    if (subject.type === 'Buffer' && isArray(subject.data))
+      subject = subject.data
+    length = +subject.length > 0 ? Math.floor(+subject.length) : 0
+  } else
+    throw new TypeError('must start with number, buffer, array or string')
+
+  if (this.length > kMaxLength)
+    throw new RangeError('Attempt to allocate Buffer larger than maximum ' +
+      'size: 0x' + kMaxLength.toString(16) + ' bytes')
+
+  var buf
+  if (Buffer.TYPED_ARRAY_SUPPORT) {
+    // Preferred: Return an augmented `Uint8Array` instance for best performance
+    buf = Buffer._augment(new Uint8Array(length))
+  } else {
+    // Fallback: Return THIS instance of Buffer (created by `new`)
+    buf = this
+    buf.length = length
+    buf._isBuffer = true
+  }
+
+  var i
+  if (Buffer.TYPED_ARRAY_SUPPORT && typeof subject.byteLength === 'number') {
+    // Speed optimization -- use set if we're copying from a typed array
+    buf._set(subject)
+  } else if (isArrayish(subject)) {
+    // Treat array-ish objects as a byte array
+    if (Buffer.isBuffer(subject)) {
+      for (i = 0; i < length; i++)
+        buf[i] = subject.readUInt8(i)
+    } else {
+      for (i = 0; i < length; i++)
+        buf[i] = ((subject[i] % 256) + 256) % 256
+    }
+  } else if (type === 'string') {
+    buf.write(subject, 0, encoding)
+  } else if (type === 'number' && !Buffer.TYPED_ARRAY_SUPPORT && !noZero) {
+    for (i = 0; i < length; i++) {
+      buf[i] = 0
+    }
+  }
+
+  return buf
+}
+
+Buffer.isBuffer = function (b) {
+  return !!(b != null && b._isBuffer)
+}
+
+Buffer.compare = function (a, b) {
+  if (!Buffer.isBuffer(a) || !Buffer.isBuffer(b))
+    throw new TypeError('Arguments must be Buffers')
+
+  var x = a.length
+  var y = b.length
+  for (var i = 0, len = Math.min(x, y); i < len && a[i] === b[i]; i++) {}
+  if (i !== len) {
+    x = a[i]
+    y = b[i]
+  }
+  if (x < y) return -1
+  if (y < x) return 1
+  return 0
+}
+
+Buffer.isEncoding = function (encoding) {
+  switch (String(encoding).toLowerCase()) {
+    case 'hex':
+    case 'utf8':
+    case 'utf-8':
+    case 'ascii':
+    case 'binary':
+    case 'base64':
+    case 'raw':
+    case 'ucs2':
+    case 'ucs-2':
+    case 'utf16le':
+    case 'utf-16le':
+      return true
+    default:
+      return false
+  }
+}
+
+Buffer.concat = function (list, totalLength) {
+  if (!isArray(list)) throw new TypeError('Usage: Buffer.concat(list[, length])')
+
+  if (list.length === 0) {
+    return new Buffer(0)
+  } else if (list.length === 1) {
+    return list[0]
+  }
+
+  var i
+  if (totalLength === undefined) {
+    totalLength = 0
+    for (i = 0; i < list.length; i++) {
+      totalLength += list[i].length
+    }
+  }
+
+  var buf = new Buffer(totalLength)
+  var pos = 0
+  for (i = 0; i < list.length; i++) {
+    var item = list[i]
+    item.copy(buf, pos)
+    pos += item.length
+  }
+  return buf
+}
+
+Buffer.byteLength = function (str, encoding) {
+  var ret
+  str = str + ''
+  switch (encoding || 'utf8') {
+    case 'ascii':
+    case 'binary':
+    case 'raw':
+      ret = str.length
+      break
+    case 'ucs2':
+    case 'ucs-2':
+    case 'utf16le':
+    case 'utf-16le':
+      ret = str.length * 2
+      break
+    case 'hex':
+      ret = str.length >>> 1
+      break
+    case 'utf8':
+    case 'utf-8':
+      ret = utf8ToBytes(str).length
+      break
+    case 'base64':
+      ret = base64ToBytes(str).length
+      break
+    default:
+      ret = str.length
+  }
+  return ret
+}
+
+// pre-set for values that may exist in the future
+Buffer.prototype.length = undefined
+Buffer.prototype.parent = undefined
+
+// toString(encoding, start=0, end=buffer.length)
+Buffer.prototype.toString = function (encoding, start, end) {
+  var loweredCase = false
+
+  start = start >>> 0
+  end = end === undefined || end === Infinity ? this.length : end >>> 0
+
+  if (!encoding) encoding = 'utf8'
+  if (start < 0) start = 0
+  if (end > this.length) end = this.length
+  if (end <= start) return ''
+
+  while (true) {
+    switch (encoding) {
+      case 'hex':
+        return hexSlice(this, start, end)
+
+      case 'utf8':
+      case 'utf-8':
+        return utf8Slice(this, start, end)
+
+      case 'ascii':
+        return asciiSlice(this, start, end)
+
+      case 'binary':
+        return binarySlice(this, start, end)
+
+      case 'base64':
+        return base64Slice(this, start, end)
+
+      case 'ucs2':
+      case 'ucs-2':
+      case 'utf16le':
+      case 'utf-16le':
+        return utf16leSlice(this, start, end)
+
+      default:
+        if (loweredCase)
+          throw new TypeError('Unknown encoding: ' + encoding)
+        encoding = (encoding + '').toLowerCase()
+        loweredCase = true
+    }
+  }
+}
+
+Buffer.prototype.equals = function (b) {
+  if(!Buffer.isBuffer(b)) throw new TypeError('Argument must be a Buffer')
+  return Buffer.compare(this, b) === 0
+}
+
+Buffer.prototype.inspect = function () {
+  var str = ''
+  var max = exports.INSPECT_MAX_BYTES
+  if (this.length > 0) {
+    str = this.toString('hex', 0, max).match(/.{2}/g).join(' ')
+    if (this.length > max)
+      str += ' ... '
+  }
+  return '<Buffer ' + str + '>'
+}
+
+Buffer.prototype.compare = function (b) {
+  if (!Buffer.isBuffer(b)) throw new TypeError('Argument must be a Buffer')
+  return Buffer.compare(this, b)
+}
+
+// `get` will be removed in Node 0.13+
+Buffer.prototype.get = function (offset) {
+  console.log('.get() is deprecated. Access using array indexes instead.')
+  return this.readUInt8(offset)
+}
+
+// `set` will be removed in Node 0.13+
+Buffer.prototype.set = function (v, offset) {
+  console.log('.set() is deprecated. Access using array indexes instead.')
+  return this.writeUInt8(v, offset)
+}
+
+function hexWrite (buf, string, offset, length) {
+  offset = Number(offset) || 0
+  var remaining = buf.length - offset
+  if (!length) {
+    length = remaining
+  } else {
+    length = Number(length)
+    if (length > remaining) {
+      length = remaining
+    }
+  }
+
+  // must be an even number of digits
+  var strLen = string.length
+  if (strLen % 2 !== 0) throw new Error('Invalid hex string')
+
+  if (length > strLen / 2) {
+    length = strLen / 2
+  }
+  for (var i = 0; i < length; i++) {
+    var byte = parseInt(string.substr(i * 2, 2), 16)
+    if (isNaN(byte)) throw new Error('Invalid hex string')
+    buf[offset + i] = byte
+  }
+  return i
+}
+
+function utf8Write (buf, string, offset, length) {
+  var charsWritten = blitBuffer(utf8ToBytes(string), buf, offset, length)
+  return charsWritten
+}
+
+function asciiWrite (buf, string, offset, length) {
+  var charsWritten = blitBuffer(asciiToBytes(string), buf, offset, length)
+  return charsWritten
+}
+
+function binaryWrite (buf, string, offset, length) {
+  return asciiWrite(buf, string, offset, length)
+}
+
+function base64Write (buf, string, offset, length) {
+  var charsWritten = blitBuffer(base64ToBytes(string), buf, offset, length)
+  return charsWritten
+}
+
+function utf16leWrite (buf, string, offset, length) {
+  var charsWritten = blitBuffer(utf16leToBytes(string), buf, offset, length, 2)
+  return charsWritten
+}
+
+Buffer.prototype.write = function (string, offset, length, encoding) {
+  // Support both (string, offset, length, encoding)
+  // and the legacy (string, encoding, offset, length)
+  if (isFinite(offset)) {
+    if (!isFinite(length)) {
+      encoding = length
+      length = undefined
+    }
+  } else {  // legacy
+    var swap = encoding
+    encoding = offset
+    offset = length
+    length = swap
+  }
+
+  offset = Number(offset) || 0
+  var remaining = this.length - offset
+  if (!length) {
+    length = remaining
+  } else {
+    length = Number(length)
+    if (length > remaining) {
+      length = remaining
+    }
+  }
+  encoding = String(encoding || 'utf8').toLowerCase()
+
+  var ret
+  switch (encoding) {
+    case 'hex':
+      ret = hexWrite(this, string, offset, length)
+      break
+    case 'utf8':
+    case 'utf-8':
+      ret = utf8Write(this, string, offset, length)
+      break
+    case 'ascii':
+      ret = asciiWrite(this, string, offset, length)
+      break
+    case 'binary':
+      ret = binaryWrite(this, string, offset, length)
+      break
+    case 'base64':
+      ret = base64Write(this, string, offset, length)
+      break
+    case 'ucs2':
+    case 'ucs-2':
+    case 'utf16le':
+    case 'utf-16le':
+      ret = utf16leWrite(this, string, offset, length)
+      break
+    default:
+      throw new TypeError('Unknown encoding: ' + encoding)
+  }
+  return ret
+}
+
+Buffer.prototype.toJSON = function () {
+  return {
+    type: 'Buffer',
+    data: Array.prototype.slice.call(this._arr || this, 0)
+  }
+}
+
+function base64Slice (buf, start, end) {
+  if (start === 0 && end === buf.length) {
+    return base64.fromByteArray(buf)
+  } else {
+    return base64.fromByteArray(buf.slice(start, end))
+  }
+}
+
+function utf8Slice (buf, start, end) {
+  var res = ''
+  var tmp = ''
+  end = Math.min(buf.length, end)
+
+  for (var i = start; i < end; i++) {
+    if (buf[i] <= 0x7F) {
+      res += decodeUtf8Char(tmp) + String.fromCharCode(buf[i])
+      tmp = ''
+    } else {
+      tmp += '%' + buf[i].toString(16)
+    }
+  }
+
+  return res + decodeUtf8Char(tmp)
+}
+
+function asciiSlice (buf, start, end) {
+  var ret = ''
+  end = Math.min(buf.length, end)
+
+  for (var i = start; i < end; i++) {
+    ret += String.fromCharCode(buf[i])
+  }
+  return ret
+}
+
+function binarySlice (buf, start, end) {
+  return asciiSlice(buf, start, end)
+}
+
+function hexSlice (buf, start, end) {
+  var len = buf.length
+
+  if (!start || start < 0) start = 0
+  if (!end || end < 0 || end > len) end = len
+
+  var out = ''
+  for (var i = start; i < end; i++) {
+    out += toHex(buf[i])
+  }
+  return out
+}
+
+function utf16leSlice (buf, start, end) {
+  var bytes = buf.slice(start, end)
+  var res = ''
+  for (var i = 0; i < bytes.length; i += 2) {
+    res += String.fromCharCode(bytes[i] + bytes[i + 1] * 256)
+  }
+  return res
+}
+
+Buffer.prototype.slice = function (start, end) {
+  var len = this.length
+  start = ~~start
+  end = end === undefined ? len : ~~end
+
+  if (start < 0) {
+    start += len;
+    if (start < 0)
+      start = 0
+  } else if (start > len) {
+    start = len
+  }
+
+  if (end < 0) {
+    end += len
+    if (end < 0)
+      end = 0
+  } else if (end > len) {
+    end = len
+  }
+
+  if (end < start)
+    end = start
+
+  if (Buffer.TYPED_ARRAY_SUPPORT) {
+    return Buffer._augment(this.subarray(start, end))
+  } else {
+    var sliceLen = end - start
+    var newBuf = new Buffer(sliceLen, undefined, true)
+    for (var i = 0; i < sliceLen; i++) {
+      newBuf[i] = this[i + start]
+    }
+    return newBuf
+  }
+}
+
+/*
+ * Need to make sure that buffer isn't trying to write out of bounds.
+ */
+function checkOffset (offset, ext, length) {
+  if ((offset % 1) !== 0 || offset < 0)
+    throw new RangeError('offset is not uint')
+  if (offset + ext > length)
+    throw new RangeError('Trying to access beyond buffer length')
+}
+
+Buffer.prototype.readUInt8 = function (offset, noAssert) {
+  if (!noAssert)
+    checkOffset(offset, 1, this.length)
+  return this[offset]
+}
+
+Buffer.prototype.readUInt16LE = function (offset, noAssert) {
+  if (!noAssert)
+    checkOffset(offset, 2, this.length)
+  return this[offset] | (this[offset + 1] << 8)
+}
+
+Buffer.prototype.readUInt16BE = function (offset, noAssert) {
+  if (!noAssert)
+    checkOffset(offset, 2, this.length)
+  return (this[offset] << 8) | this[offset + 1]
+}
+
+Buffer.prototype.readUInt32LE = function (offset, noAssert) {
+  if (!noAssert)
+    checkOffset(offset, 4, this.length)
+
+  return ((this[offset]) |
+      (this[offset + 1] << 8) |
+      (this[offset + 2] << 16)) +
+      (this[offset + 3] * 0x1000000)
+}
+
+Buffer.prototype.readUInt32BE = function (offset, noAssert) {
+  if (!noAssert)
+    checkOffset(offset, 4, this.length)
+
+  return (this[offset] * 0x1000000) +
+      ((this[offset + 1] << 16) |
+      (this[offset + 2] << 8) |
+      this[offset + 3])
+}
+
+Buffer.prototype.readInt8 = function (offset, noAssert) {
+  if (!noAssert)
+    checkOffset(offset, 1, this.length)
+  if (!(this[offset] & 0x80))
+    return (this[offset])
+  return ((0xff - this[offset] + 1) * -1)
+}
+
+Buffer.prototype.readInt16LE = function (offset, noAssert) {
+  if (!noAssert)
+    checkOffset(offset, 2, this.length)
+  var val = this[offset] | (this[offset + 1] << 8)
+  return (val & 0x8000) ? val | 0xFFFF0000 : val
+}
+
+Buffer.prototype.readInt16BE = function (offset, noAssert) {
+  if (!noAssert)
+    checkOffset(offset, 2, this.length)
+  var val = this[offset + 1] | (this[offset] << 8)
+  return (val & 0x8000) ? val | 0xFFFF0000 : val
+}
+
+Buffer.prototype.readInt32LE = function (offset, noAssert) {
+  if (!noAssert)
+    checkOffset(offset, 4, this.length)
+
+  return (this[offset]) |
+      (this[offset + 1] << 8) |
+      (this[offset + 2] << 16) |
+      (this[offset + 3] << 24)
+}
+
+Buffer.prototype.readInt32BE = function (offset, noAssert) {
+  if (!noAssert)
+    checkOffset(offset, 4, this.length)
+
+  return (this[offset] << 24) |
+      (this[offset + 1] << 16) |
+      (this[offset + 2] << 8) |
+      (this[offset + 3])
+}
+
+Buffer.prototype.readFloatLE = function (offset, noAssert) {
+  if (!noAssert)
+    checkOffset(offset, 4, this.length)
+  return ieee754.read(this, offset, true, 23, 4)
+}
+
+Buffer.prototype.readFloatBE = function (offset, noAssert) {
+  if (!noAssert)
+    checkOffset(offset, 4, this.length)
+  return ieee754.read(this, offset, false, 23, 4)
+}
+
+Buffer.prototype.readDoubleLE = function (offset, noAssert) {
+  if (!noAssert)
+    checkOffset(offset, 8, this.length)
+  return ieee754.read(this, offset, true, 52, 8)
+}
+
+Buffer.prototype.readDoubleBE = function (offset, noAssert) {
+  if (!noAssert)
+    checkOffset(offset, 8, this.length)
+  return ieee754.read(this, offset, false, 52, 8)
+}
+
+function checkInt (buf, value, offset, ext, max, min) {
+  if (!Buffer.isBuffer(buf)) throw new TypeError('buffer must be a Buffer instance')
+  if (value > max || value < min) throw new TypeError('value is out of bounds')
+  if (offset + ext > buf.length) throw new TypeError('index out of range')
+}
+
+Buffer.prototype.writeUInt8 = function (value, offset, noAssert) {
+  value = +value
+  offset = offset >>> 0
+  if (!noAssert)
+    checkInt(this, value, offset, 1, 0xff, 0)
+  if (!Buffer.TYPED_ARRAY_SUPPORT) value = Math.floor(value)
+  this[offset] = value
+  return offset + 1
+}
+
+function objectWriteUInt16 (buf, value, offset, littleEndian) {
+  if (value < 0) value = 0xffff + value + 1
+  for (var i = 0, j = Math.min(buf.length - offset, 2); i < j; i++) {
+    buf[offset + i] = (value & (0xff << (8 * (littleEndian ? i : 1 - i)))) >>>
+      (littleEndian ? i : 1 - i) * 8
+  }
+}
+
+Buffer.prototype.writeUInt16LE = function (value, offset, noAssert) {
+  value = +value
+  offset = offset >>> 0
+  if (!noAssert)
+    checkInt(this, value, offset, 2, 0xffff, 0)
+  if (Buffer.TYPED_ARRAY_SUPPORT) {
+    this[offset] = value
+    this[offset + 1] = (value >>> 8)
+  } else objectWriteUInt16(this, value, offset, true)
+  return offset + 2
+}
+
+Buffer.prototype.writeUInt16BE = function (value, offset, noAssert) {
+  value = +value
+  offset = offset >>> 0
+  if (!noAssert)
+    checkInt(this, value, offset, 2, 0xffff, 0)
+  if (Buffer.TYPED_ARRAY_SUPPORT) {
+    this[offset] = (value >>> 8)
+    this[offset + 1] = value
+  } else objectWriteUInt16(this, value, offset, false)
+  return offset + 2
+}
+
+function objectWriteUInt32 (buf, value, offset, littleEndian) {
+  if (value < 0) value = 0xffffffff + value + 1
+  for (var i = 0, j = Math.min(buf.length - offset, 4); i < j; i++) {
+    buf[offset + i] = (value >>> (littleEndian ? i : 3 - i) * 8) & 0xff
+  }
+}
+
+Buffer.prototype.writeUInt32LE = function (value, offset, noAssert) {
+  value = +value
+  offset = offset >>> 0
+  if (!noAssert)
+    checkInt(this, value, offset, 4, 0xffffffff, 0)
+  if (Buffer.TYPED_ARRAY_SUPPORT) {
+    this[offset + 3] = (value >>> 24)
+    this[offset + 2] = (value >>> 16)
+    this[offset + 1] = (value >>> 8)
+    this[offset] = value
+  } else objectWriteUInt32(this, value, offset, true)
+  return offset + 4
+}
+
+Buffer.prototype.writeUInt32BE = function (value, offset, noAssert) {
+  value = +value
+  offset = offset >>> 0
+  if (!noAssert)
+    checkInt(this, value, offset, 4, 0xffffffff, 0)
+  if (Buffer.TYPED_ARRAY_SUPPORT) {
+    this[offset] = (value >>> 24)
+    this[offset + 1] = (value >>> 16)
+    this[offset + 2] = (value >>> 8)
+    this[offset + 3] = value
+  } else objectWriteUInt32(this, value, offset, false)
+  return offset + 4
+}
+
+Buffer.prototype.writeInt8 = function (value, offset, noAssert) {
+  value = +value
+  offset = offset >>> 0
+  if (!noAssert)
+    checkInt(this, value, offset, 1, 0x7f, -0x80)
+  if (!Buffer.TYPED_ARRAY_SUPPORT) value = Math.floor(value)
+  if (value < 0) value = 0xff + value + 1
+  this[offset] = value
+  return offset + 1
+}
+
+Buffer.prototype.writeInt16LE = function (value, offset, noAssert) {
+  value = +value
+  offset = offset >>> 0
+  if (!noAssert)
+    checkInt(this, value, offset, 2, 0x7fff, -0x8000)
+  if (Buffer.TYPED_ARRAY_SUPPORT) {
+    this[offset] = value
+    this[offset + 1] = (value >>> 8)
+  } else objectWriteUInt16(this, value, offset, true)
+  return offset + 2
+}
+
+Buffer.prototype.writeInt16BE = function (value, offset, noAssert) {
+  value = +value
+  offset = offset >>> 0
+  if (!noAssert)
+    checkInt(this, value, offset, 2, 0x7fff, -0x8000)
+  if (Buffer.TYPED_ARRAY_SUPPORT) {
+    this[offset] = (value >>> 8)
+    this[offset + 1] = value
+  } else objectWriteUInt16(this, value, offset, false)
+  return offset + 2
+}
+
+Buffer.prototype.writeInt32LE = function (value, offset, noAssert) {
+  value = +value
+  offset = offset >>> 0
+  if (!noAssert)
+    checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000)
+  if (Buffer.TYPED_ARRAY_SUPPORT) {
+    this[offset] = value
+    this[offset + 1] = (value >>> 8)
+    this[offset + 2] = (value >>> 16)
+    this[offset + 3] = (value >>> 24)
+  } else objectWriteUInt32(this, value, offset, true)
+  return offset + 4
+}
+
+Buffer.prototype.writeInt32BE = function (value, offset, noAssert) {
+  value = +value
+  offset = offset >>> 0
+  if (!noAssert)
+    checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000)
+  if (value < 0) value = 0xffffffff + value + 1
+  if (Buffer.TYPED_ARRAY_SUPPORT) {
+    this[offset] = (value >>> 24)
+    this[offset + 1] = (value >>> 16)
+    this[offset + 2] = (value >>> 8)
+    this[offset + 3] = value
+  } else objectWriteUInt32(this, value, offset, false)
+  return offset + 4
+}
+
+function checkIEEE754 (buf, value, offset, ext, max, min) {
+  if (value > max || value < min) throw new TypeError('value is out of bounds')
+  if (offset + ext > buf.length) throw new TypeError('index out of range')
+}
+
+function writeFloat (buf, value, offset, littleEndian, noAssert) {
+  if (!noAssert)
+    checkIEEE754(buf, value, offset, 4, 3.4028234663852886e+38, -3.4028234663852886e+38)
+  ieee754.write(buf, value, offset, littleEndian, 23, 4)
+  return offset + 4
+}
+
+Buffer.prototype.writeFloatLE = function (value, offset, noAssert) {
+  return writeFloat(this, value, offset, true, noAssert)
+}
+
+Buffer.prototype.writeFloatBE = function (value, offset, noAssert) {
+  return writeFloat(this, value, offset, false, noAssert)
+}
+
+function writeDouble (buf, value, offset, littleEndian, noAssert) {
+  if (!noAssert)
+    checkIEEE754(buf, value, offset, 8, 1.7976931348623157E+308, -1.7976931348623157E+308)
+  ieee754.write(buf, value, offset, littleEndian, 52, 8)
+  return offset + 8
+}
+
+Buffer.prototype.writeDoubleLE = function (value, offset, noAssert) {
+  return writeDouble(this, value, offset, true, noAssert)
+}
+
+Buffer.prototype.writeDoubleBE = function (value, offset, noAssert) {
+  return writeDouble(this, value, offset, false, noAssert)
+}
+
+// copy(targetBuffer, targetStart=0, sourceStart=0, sourceEnd=buffer.length)
+Buffer.prototype.copy = function (target, target_start, start, end) {
+  var source = this
+
+  if (!start) start = 0
+  if (!end && end !== 0) end = this.length
+  if (!target_start) target_start = 0
+
+  // Copy 0 bytes; we're done
+  if (end === start) return
+  if (target.length === 0 || source.length === 0) return
+
+  // Fatal error conditions
+  if (end < start) throw new TypeError('sourceEnd < sourceStart')
+  if (target_start < 0 || target_start >= target.length)
+    throw new TypeError('targetStart out of bounds')
+  if (start < 0 || start >= source.length) throw new TypeError('sourceStart out of bounds')
+  if (end < 0 || end > source.length) throw new TypeError('sourceEnd out of bounds')
+
+  // Are we oob?
+  if (end > this.length)
+    end = this.length
+  if (target.length - target_start < end - start)
+    end = target.length - target_start + start
+
+  var len = end - start
+
+  if (len < 1000 || !Buffer.TYPED_ARRAY_SUPPORT) {
+    for (var i = 0; i < len; i++) {
+      target[i + target_start] = this[i + start]
+    }
+  } else {
+    target._set(this.subarray(start, start + len), target_start)
+  }
+}
+
+// fill(value, start=0, end=buffer.length)
+Buffer.prototype.fill = function (value, start, end) {
+  if (!value) value = 0
+  if (!start) start = 0
+  if (!end) end = this.length
+
+  if (end < start) throw new TypeError('end < start')
+
+  // Fill 0 bytes; we're done
+  if (end === start) return
+  if (this.length === 0) return
+
+  if (start < 0 || start >= this.length) throw new TypeError('start out of bounds')
+  if (end < 0 || end > this.length) throw new TypeError('end out of bounds')
+
+  var i
+  if (typeof value === 'number') {
+    for (i = start; i < end; i++) {
+      this[i] = value
+    }
+  } else {
+    var bytes = utf8ToBytes(value.toString())
+    var len = bytes.length
+    for (i = start; i < end; i++) {
+      this[i] = bytes[i % len]
+    }
+  }
+
+  return this
+}
+
+/**
+ * Creates a new `ArrayBuffer` with the *copied* memory of the buffer instance.
+ * Added in Node 0.12. Only available in browsers that support ArrayBuffer.
+ */
+Buffer.prototype.toArrayBuffer = function () {
+  if (typeof Uint8Array !== 'undefined') {
+    if (Buffer.TYPED_ARRAY_SUPPORT) {
+      return (new Buffer(this)).buffer
+    } else {
+      var buf = new Uint8Array(this.length)
+      for (var i = 0, len = buf.length; i < len; i += 1) {
+        buf[i] = this[i]
+      }
+      return buf.buffer
+    }
+  } else {
+    throw new TypeError('Buffer.toArrayBuffer not supported in this browser')
+  }
+}
+
+// HELPER FUNCTIONS
+// ================
+
+var BP = Buffer.prototype
+
+/**
+ * Augment a Uint8Array *instance* (not the Uint8Array class!) with Buffer methods
+ */
+Buffer._augment = function (arr) {
+  arr.constructor = Buffer
+  arr._isBuffer = true
+
+  // save reference to original Uint8Array get/set methods before overwriting
+  arr._get = arr.get
+  arr._set = arr.set
+
+  // deprecated, will be removed in node 0.13+
+  arr.get = BP.get
+  arr.set = BP.set
+
+  arr.write = BP.write
+  arr.toString = BP.toString
+  arr.toLocaleString = BP.toString
+  arr.toJSON = BP.toJSON
+  arr.equals = BP.equals
+  arr.compare = BP.compare
+  arr.copy = BP.copy
+  arr.slice = BP.slice
+  arr.readUInt8 = BP.readUInt8
+  arr.readUInt16LE = BP.readUInt16LE
+  arr.readUInt16BE = BP.readUInt16BE
+  arr.readUInt32LE = BP.readUInt32LE
+  arr.readUInt32BE = BP.readUInt32BE
+  arr.readInt8 = BP.readInt8
+  arr.readInt16LE = BP.readInt16LE
+  arr.readInt16BE = BP.readInt16BE
+  arr.readInt32LE = BP.readInt32LE
+  arr.readInt32BE = BP.readInt32BE
+  arr.readFloatLE = BP.readFloatLE
+  arr.readFloatBE = BP.readFloatBE
+  arr.readDoubleLE = BP.readDoubleLE
+  arr.readDoubleBE = BP.readDoubleBE
+  arr.writeUInt8 = BP.writeUInt8
+  arr.writeUInt16LE = BP.writeUInt16LE
+  arr.writeUInt16BE = BP.writeUInt16BE
+  arr.writeUInt32LE = BP.writeUInt32LE
+  arr.writeUInt32BE = BP.writeUInt32BE
+  arr.writeInt8 = BP.writeInt8
+  arr.writeInt16LE = BP.writeInt16LE
+  arr.writeInt16BE = BP.writeInt16BE
+  arr.writeInt32LE = BP.writeInt32LE
+  arr.writeInt32BE = BP.writeInt32BE
+  arr.writeFloatLE = BP.writeFloatLE
+  arr.writeFloatBE = BP.writeFloatBE
+  arr.writeDoubleLE = BP.writeDoubleLE
+  arr.writeDoubleBE = BP.writeDoubleBE
+  arr.fill = BP.fill
+  arr.inspect = BP.inspect
+  arr.toArrayBuffer = BP.toArrayBuffer
+
+  return arr
+}
+
+var INVALID_BASE64_RE = /[^+\/0-9A-z]/g
+
+function base64clean (str) {
+  // Node strips out invalid characters like \n and \t from the string, base64-js does not
+  str = stringtrim(str).replace(INVALID_BASE64_RE, '')
+  // Node allows for non-padded base64 strings (missing trailing ===), base64-js does not
+  while (str.length % 4 !== 0) {
+    str = str + '='
+  }
+  return str
+}
+
+function stringtrim (str) {
+  if (str.trim) return str.trim()
+  return str.replace(/^\s+|\s+$/g, '')
+}
+
+function isArrayish (subject) {
+  return isArray(subject) || Buffer.isBuffer(subject) ||
+      subject && typeof subject === 'object' &&
+      typeof subject.length === 'number'
+}
+
+function toHex (n) {
+  if (n < 16) return '0' + n.toString(16)
+  return n.toString(16)
+}
+
+function utf8ToBytes (str) {
+  var byteArray = []
+  for (var i = 0; i < str.length; i++) {
+    var b = str.charCodeAt(i)
+    if (b <= 0x7F) {
+      byteArray.push(b)
+    } else {
+      var start = i
+      if (b >= 0xD800 && b <= 0xDFFF) i++
+      var h = encodeURIComponent(str.slice(start, i+1)).substr(1).split('%')
+      for (var j = 0; j < h.length; j++) {
+        byteArray.push(parseInt(h[j], 16))
+      }
+    }
+  }
+  return byteArray
+}
+
+function asciiToBytes (str) {
+  var byteArray = []
+  for (var i = 0; i < str.length; i++) {
+    // Node's code seems to be doing this and not & 0x7F..
+    byteArray.push(str.charCodeAt(i) & 0xFF)
+  }
+  return byteArray
+}
+
+function utf16leToBytes (str) {
+  var c, hi, lo
+  var byteArray = []
+  for (var i = 0; i < str.length; i++) {
+    c = str.charCodeAt(i)
+    hi = c >> 8
+    lo = c % 256
+    byteArray.push(lo)
+    byteArray.push(hi)
+  }
+
+  return byteArray
+}
+
+function base64ToBytes (str) {
+  return base64.toByteArray(str)
+}
+
+function blitBuffer (src, dst, offset, length, unitSize) {
+  if (unitSize) length -= length % unitSize;
+  for (var i = 0; i < length; i++) {
+    if ((i + offset >= dst.length) || (i >= src.length))
+      break
+    dst[i + offset] = src[i]
+  }
+  return i
+}
+
+function decodeUtf8Char (str) {
+  try {
+    return decodeURIComponent(str)
+  } catch (err) {
+    return String.fromCharCode(0xFFFD) // UTF 8 invalid char
+  }
+}
+
+},{}],20:[function(require,module,exports){
+var lookup = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+;(function (exports) {
+	'use strict';
+
+  var Arr = (typeof Uint8Array !== 'undefined')
+    ? Uint8Array
+    : Array
+
+	var PLUS   = '+'.charCodeAt(0)
+	var SLASH  = '/'.charCodeAt(0)
+	var NUMBER = '0'.charCodeAt(0)
+	var LOWER  = 'a'.charCodeAt(0)
+	var UPPER  = 'A'.charCodeAt(0)
+
+	function decode (elt) {
+		var code = elt.charCodeAt(0)
+		if (code === PLUS)
+			return 62 // '+'
+		if (code === SLASH)
+			return 63 // '/'
+		if (code < NUMBER)
+			return -1 //no match
+		if (code < NUMBER + 10)
+			return code - NUMBER + 26 + 26
+		if (code < UPPER + 26)
+			return code - UPPER
+		if (code < LOWER + 26)
+			return code - LOWER + 26
+	}
+
+	function b64ToByteArray (b64) {
+		var i, j, l, tmp, placeHolders, arr
+
+		if (b64.length % 4 > 0) {
+			throw new Error('Invalid string. Length must be a multiple of 4')
+		}
+
+		// the number of equal signs (place holders)
+		// if there are two placeholders, than the two characters before it
+		// represent one byte
+		// if there is only one, then the three characters before it represent 2 bytes
+		// this is just a cheap hack to not do indexOf twice
+		var len = b64.length
+		placeHolders = '=' === b64.charAt(len - 2) ? 2 : '=' === b64.charAt(len - 1) ? 1 : 0
+
+		// base64 is 4/3 + up to two characters of the original data
+		arr = new Arr(b64.length * 3 / 4 - placeHolders)
+
+		// if there are placeholders, only get up to the last complete 4 chars
+		l = placeHolders > 0 ? b64.length - 4 : b64.length
+
+		var L = 0
+
+		function push (v) {
+			arr[L++] = v
+		}
+
+		for (i = 0, j = 0; i < l; i += 4, j += 3) {
+			tmp = (decode(b64.charAt(i)) << 18) | (decode(b64.charAt(i + 1)) << 12) | (decode(b64.charAt(i + 2)) << 6) | decode(b64.charAt(i + 3))
+			push((tmp & 0xFF0000) >> 16)
+			push((tmp & 0xFF00) >> 8)
+			push(tmp & 0xFF)
+		}
+
+		if (placeHolders === 2) {
+			tmp = (decode(b64.charAt(i)) << 2) | (decode(b64.charAt(i + 1)) >> 4)
+			push(tmp & 0xFF)
+		} else if (placeHolders === 1) {
+			tmp = (decode(b64.charAt(i)) << 10) | (decode(b64.charAt(i + 1)) << 4) | (decode(b64.charAt(i + 2)) >> 2)
+			push((tmp >> 8) & 0xFF)
+			push(tmp & 0xFF)
+		}
+
+		return arr
+	}
+
+	function uint8ToBase64 (uint8) {
+		var i,
+			extraBytes = uint8.length % 3, // if we have 1 byte left, pad 2 bytes
+			output = "",
+			temp, length
+
+		function encode (num) {
+			return lookup.charAt(num)
+		}
+
+		function tripletToBase64 (num) {
+			return encode(num >> 18 & 0x3F) + encode(num >> 12 & 0x3F) + encode(num >> 6 & 0x3F) + encode(num & 0x3F)
+		}
+
+		// go through the array every three bytes, we'll deal with trailing stuff later
+		for (i = 0, length = uint8.length - extraBytes; i < length; i += 3) {
+			temp = (uint8[i] << 16) + (uint8[i + 1] << 8) + (uint8[i + 2])
+			output += tripletToBase64(temp)
+		}
+
+		// pad the end with zeros, but make sure to not forget the extra bytes
+		switch (extraBytes) {
+			case 1:
+				temp = uint8[uint8.length - 1]
+				output += encode(temp >> 2)
+				output += encode((temp << 4) & 0x3F)
+				output += '=='
+				break
+			case 2:
+				temp = (uint8[uint8.length - 2] << 8) + (uint8[uint8.length - 1])
+				output += encode(temp >> 10)
+				output += encode((temp >> 4) & 0x3F)
+				output += encode((temp << 2) & 0x3F)
+				output += '='
+				break
+		}
+
+		return output
+	}
+
+	exports.toByteArray = b64ToByteArray
+	exports.fromByteArray = uint8ToBase64
+}(typeof exports === 'undefined' ? (this.base64js = {}) : exports))
+
+},{}],21:[function(require,module,exports){
+exports.read = function (buffer, offset, isLE, mLen, nBytes) {
+  var e, m
+  var eLen = nBytes * 8 - mLen - 1
+  var eMax = (1 << eLen) - 1
+  var eBias = eMax >> 1
+  var nBits = -7
+  var i = isLE ? (nBytes - 1) : 0
+  var d = isLE ? -1 : 1
+  var s = buffer[offset + i]
+
+  i += d
+
+  e = s & ((1 << (-nBits)) - 1)
+  s >>= (-nBits)
+  nBits += eLen
+  for (; nBits > 0; e = e * 256 + buffer[offset + i], i += d, nBits -= 8) {}
+
+  m = e & ((1 << (-nBits)) - 1)
+  e >>= (-nBits)
+  nBits += mLen
+  for (; nBits > 0; m = m * 256 + buffer[offset + i], i += d, nBits -= 8) {}
+
+  if (e === 0) {
+    e = 1 - eBias
+  } else if (e === eMax) {
+    return m ? NaN : ((s ? -1 : 1) * Infinity)
+  } else {
+    m = m + Math.pow(2, mLen)
+    e = e - eBias
+  }
+  return (s ? -1 : 1) * m * Math.pow(2, e - mLen)
+}
+
+exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
+  var e, m, c
+  var eLen = nBytes * 8 - mLen - 1
+  var eMax = (1 << eLen) - 1
+  var eBias = eMax >> 1
+  var rt = (mLen === 23 ? Math.pow(2, -24) - Math.pow(2, -77) : 0)
+  var i = isLE ? 0 : (nBytes - 1)
+  var d = isLE ? 1 : -1
+  var s = value < 0 || (value === 0 && 1 / value < 0) ? 1 : 0
+
+  value = Math.abs(value)
+
+  if (isNaN(value) || value === Infinity) {
+    m = isNaN(value) ? 1 : 0
+    e = eMax
+  } else {
+    e = Math.floor(Math.log(value) / Math.LN2)
+    if (value * (c = Math.pow(2, -e)) < 1) {
+      e--
+      c *= 2
+    }
+    if (e + eBias >= 1) {
+      value += rt / c
+    } else {
+      value += rt * Math.pow(2, 1 - eBias)
+    }
+    if (value * c >= 2) {
+      e++
+      c /= 2
+    }
+
+    if (e + eBias >= eMax) {
+      m = 0
+      e = eMax
+    } else if (e + eBias >= 1) {
+      m = (value * c - 1) * Math.pow(2, mLen)
+      e = e + eBias
+    } else {
+      m = value * Math.pow(2, eBias - 1) * Math.pow(2, mLen)
+      e = 0
+    }
+  }
+
+  for (; mLen >= 8; buffer[offset + i] = m & 0xff, i += d, m /= 256, mLen -= 8) {}
+
+  e = (e << mLen) | m
+  eLen += mLen
+  for (; eLen > 0; buffer[offset + i] = e & 0xff, i += d, e /= 256, eLen -= 8) {}
+
+  buffer[offset + i - d] |= s * 128
+}
+
+},{}],22:[function(require,module,exports){
+
+/**
+ * isArray
+ */
+
+var isArray = Array.isArray;
+
+/**
+ * toString
+ */
+
+var str = Object.prototype.toString;
+
+/**
+ * Whether or not the given `val`
+ * is an array.
+ *
+ * example:
+ *
+ *        isArray([]);
+ *        // > true
+ *        isArray(arguments);
+ *        // > false
+ *        isArray('');
+ *        // > false
+ *
+ * @param {mixed} val
+ * @return {bool}
+ */
+
+module.exports = isArray || function (val) {
+  return !! val && '[object Array]' == str.call(val);
+};
+
+},{}],23:[function(require,module,exports){
+// shim for using process in browser
+
+var process = module.exports = {};
+
+process.nextTick = (function () {
+    var canSetImmediate = typeof window !== 'undefined'
+    && window.setImmediate;
+    var canPost = typeof window !== 'undefined'
+    && window.postMessage && window.addEventListener
+    ;
+
+    if (canSetImmediate) {
+        return function (f) { return window.setImmediate(f) };
+    }
+
+    if (canPost) {
+        var queue = [];
+        window.addEventListener('message', function (ev) {
+            var source = ev.source;
+            if ((source === window || source === null) && ev.data === 'process-tick') {
+                ev.stopPropagation();
+                if (queue.length > 0) {
+                    var fn = queue.shift();
+                    fn();
+                }
+            }
+        }, true);
+
+        return function nextTick(fn) {
+            queue.push(fn);
+            window.postMessage('process-tick', '*');
+        };
+    }
+
+    return function nextTick(fn) {
+        setTimeout(fn, 0);
+    };
+})();
+
+process.title = 'browser';
+process.browser = true;
+process.env = {};
+process.argv = [];
+
+function noop() {}
+
+process.on = noop;
+process.addListener = noop;
+process.once = noop;
+process.off = noop;
+process.removeListener = noop;
+process.removeAllListeners = noop;
+process.emit = noop;
+
+process.binding = function (name) {
+    throw new Error('process.binding is not supported');
+}
+
+// TODO(shtylman)
+process.cwd = function () { return '/' };
+process.chdir = function (dir) {
+    throw new Error('process.chdir is not supported');
+};
+
+},{}],24:[function(require,module,exports){
+/* See LICENSE file for terms of use */
+
+/*
+ * Text diff implementation.
+ *
+ * This library supports the following APIS:
+ * JsDiff.diffChars: Character by character diff
+ * JsDiff.diffWords: Word (as defined by \b regex) diff which ignores whitespace
+ * JsDiff.diffLines: Line based diff
+ *
+ * JsDiff.diffCss: Diff targeted at CSS content
+ *
+ * These methods are based on the implementation proposed in
+ * "An O(ND) Difference Algorithm and its Variations" (Myers, 1986).
+ * http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.4.6927
+ */
+(function(global, undefined) {
+  var JsDiff = (function() {
+    /*jshint maxparams: 5*/
+    function map(arr, mapper, that) {
+      if (Array.prototype.map) {
+        return Array.prototype.map.call(arr, mapper, that);
+      }
+
+      var other = new Array(arr.length);
+
+      for (var i = 0, n = arr.length; i < n; i++) {
+        other[i] = mapper.call(that, arr[i], i, arr);
+      }
+      return other;
+    }
+    function clonePath(path) {
+      return { newPos: path.newPos, components: path.components.slice(0) };
+    }
+    function removeEmpty(array) {
+      var ret = [];
+      for (var i = 0; i < array.length; i++) {
+        if (array[i]) {
+          ret.push(array[i]);
+        }
+      }
+      return ret;
+    }
+    function escapeHTML(s) {
+      var n = s;
+      n = n.replace(/&/g, '&amp;');
+      n = n.replace(/</g, '&lt;');
+      n = n.replace(/>/g, '&gt;');
+      n = n.replace(/"/g, '&quot;');
+
+      return n;
+    }
+
+    var Diff = function(ignoreWhitespace) {
+      this.ignoreWhitespace = ignoreWhitespace;
+    };
+    Diff.prototype = {
+        diff: function(oldString, newString) {
+          // Handle the identity case (this is due to unrolling editLength == 0
+          if (newString === oldString) {
+            return [{ value: newString }];
+          }
+          if (!newString) {
+            return [{ value: oldString, removed: true }];
+          }
+          if (!oldString) {
+            return [{ value: newString, added: true }];
+          }
+
+          newString = this.tokenize(newString);
+          oldString = this.tokenize(oldString);
+
+          var newLen = newString.length, oldLen = oldString.length;
+          var maxEditLength = newLen + oldLen;
+          var bestPath = [{ newPos: -1, components: [] }];
+
+          // Seed editLength = 0
+          var oldPos = this.extractCommon(bestPath[0], newString, oldString, 0);
+          if (bestPath[0].newPos+1 >= newLen && oldPos+1 >= oldLen) {
+            return bestPath[0].components;
+          }
+
+          for (var editLength = 1; editLength <= maxEditLength; editLength++) {
+            for (var diagonalPath = -1*editLength; diagonalPath <= editLength; diagonalPath+=2) {
+              var basePath;
+              var addPath = bestPath[diagonalPath-1],
+                  removePath = bestPath[diagonalPath+1];
+              oldPos = (removePath ? removePath.newPos : 0) - diagonalPath;
+              if (addPath) {
+                // No one else is going to attempt to use this value, clear it
+                bestPath[diagonalPath-1] = undefined;
+              }
+
+              var canAdd = addPath && addPath.newPos+1 < newLen;
+              var canRemove = removePath && 0 <= oldPos && oldPos < oldLen;
+              if (!canAdd && !canRemove) {
+                bestPath[diagonalPath] = undefined;
+                continue;
+              }
+
+              // Select the diagonal that we want to branch from. We select the prior
+              // path whose position in the new string is the farthest from the origin
+              // and does not pass the bounds of the diff graph
+              if (!canAdd || (canRemove && addPath.newPos < removePath.newPos)) {
+                basePath = clonePath(removePath);
+                this.pushComponent(basePath.components, oldString[oldPos], undefined, true);
+              } else {
+                basePath = clonePath(addPath);
+                basePath.newPos++;
+                this.pushComponent(basePath.components, newString[basePath.newPos], true, undefined);
+              }
+
+              var oldPos = this.extractCommon(basePath, newString, oldString, diagonalPath);
+
+              if (basePath.newPos+1 >= newLen && oldPos+1 >= oldLen) {
+                return basePath.components;
+              } else {
+                bestPath[diagonalPath] = basePath;
+              }
+            }
+          }
+        },
+
+        pushComponent: function(components, value, added, removed) {
+          var last = components[components.length-1];
+          if (last && last.added === added && last.removed === removed) {
+            // We need to clone here as the component clone operation is just
+            // as shallow array clone
+            components[components.length-1] =
+              {value: this.join(last.value, value), added: added, removed: removed };
+          } else {
+            components.push({value: value, added: added, removed: removed });
+          }
+        },
+        extractCommon: function(basePath, newString, oldString, diagonalPath) {
+          var newLen = newString.length,
+              oldLen = oldString.length,
+              newPos = basePath.newPos,
+              oldPos = newPos - diagonalPath;
+          while (newPos+1 < newLen && oldPos+1 < oldLen && this.equals(newString[newPos+1], oldString[oldPos+1])) {
+            newPos++;
+            oldPos++;
+
+            this.pushComponent(basePath.components, newString[newPos], undefined, undefined);
+          }
+          basePath.newPos = newPos;
+          return oldPos;
+        },
+
+        equals: function(left, right) {
+          var reWhitespace = /\S/;
+          if (this.ignoreWhitespace && !reWhitespace.test(left) && !reWhitespace.test(right)) {
+            return true;
+          } else {
+            return left === right;
+          }
+        },
+        join: function(left, right) {
+          return left + right;
+        },
+        tokenize: function(value) {
+          return value;
+        }
+    };
+
+    var CharDiff = new Diff();
+
+    var WordDiff = new Diff(true);
+    var WordWithSpaceDiff = new Diff();
+    WordDiff.tokenize = WordWithSpaceDiff.tokenize = function(value) {
+      return removeEmpty(value.split(/(\s+|\b)/));
+    };
+
+    var CssDiff = new Diff(true);
+    CssDiff.tokenize = function(value) {
+      return removeEmpty(value.split(/([{}:;,]|\s+)/));
+    };
+
+    var LineDiff = new Diff();
+    LineDiff.tokenize = function(value) {
+      var retLines = [],
+          lines = value.split(/^/m);
+
+      for(var i = 0; i < lines.length; i++) {
+        var line = lines[i],
+            lastLine = lines[i - 1];
+
+        // Merge lines that may contain windows new lines
+        if (line == '\n' && lastLine && lastLine[lastLine.length - 1] === '\r') {
+          retLines[retLines.length - 1] += '\n';
+        } else if (line) {
+          retLines.push(line);
+        }
+      }
+
+      return retLines;
+    };
+
+    return {
+      Diff: Diff,
+
+      diffChars: function(oldStr, newStr) { return CharDiff.diff(oldStr, newStr); },
+      diffWords: function(oldStr, newStr) { return WordDiff.diff(oldStr, newStr); },
+      diffWordsWithSpace: function(oldStr, newStr) { return WordWithSpaceDiff.diff(oldStr, newStr); },
+      diffLines: function(oldStr, newStr) { return LineDiff.diff(oldStr, newStr); },
+
+      diffCss: function(oldStr, newStr) { return CssDiff.diff(oldStr, newStr); },
+
+      createPatch: function(fileName, oldStr, newStr, oldHeader, newHeader) {
+        var ret = [];
+
+        ret.push('Index: ' + fileName);
+        ret.push('===================================================================');
+        ret.push('--- ' + fileName + (typeof oldHeader === 'undefined' ? '' : '\t' + oldHeader));
+        ret.push('+++ ' + fileName + (typeof newHeader === 'undefined' ? '' : '\t' + newHeader));
+
+        var diff = LineDiff.diff(oldStr, newStr);
+        if (!diff[diff.length-1].value) {
+          diff.pop();   // Remove trailing newline add
+        }
+        diff.push({value: '', lines: []});   // Append an empty value to make cleanup easier
+
+        function contextLines(lines) {
+          return map(lines, function(entry) { return ' ' + entry; });
+        }
+        function eofNL(curRange, i, current) {
+          var last = diff[diff.length-2],
+              isLast = i === diff.length-2,
+              isLastOfType = i === diff.length-3 && (current.added !== last.added || current.removed !== last.removed);
+
+          // Figure out if this is the last line for the given file and missing NL
+          if (!/\n$/.test(current.value) && (isLast || isLastOfType)) {
+            curRange.push('\\ No newline at end of file');
+          }
+        }
+
+        var oldRangeStart = 0, newRangeStart = 0, curRange = [],
+            oldLine = 1, newLine = 1;
+        for (var i = 0; i < diff.length; i++) {
+          var current = diff[i],
+              lines = current.lines || current.value.replace(/\n$/, '').split('\n');
+          current.lines = lines;
+
+          if (current.added || current.removed) {
+            if (!oldRangeStart) {
+              var prev = diff[i-1];
+              oldRangeStart = oldLine;
+              newRangeStart = newLine;
+
+              if (prev) {
+                curRange = contextLines(prev.lines.slice(-4));
+                oldRangeStart -= curRange.length;
+                newRangeStart -= curRange.length;
+              }
+            }
+            curRange.push.apply(curRange, map(lines, function(entry) { return (current.added?'+':'-') + entry; }));
+            eofNL(curRange, i, current);
+
+            if (current.added) {
+              newLine += lines.length;
+            } else {
+              oldLine += lines.length;
+            }
+          } else {
+            if (oldRangeStart) {
+              // Close out any changes that have been output (or join overlapping)
+              if (lines.length <= 8 && i < diff.length-2) {
+                // Overlapping
+                curRange.push.apply(curRange, contextLines(lines));
+              } else {
+                // end the range and output
+                var contextSize = Math.min(lines.length, 4);
+                ret.push(
+                    '@@ -' + oldRangeStart + ',' + (oldLine-oldRangeStart+contextSize)
+                    + ' +' + newRangeStart + ',' + (newLine-newRangeStart+contextSize)
+                    + ' @@');
+                ret.push.apply(ret, curRange);
+                ret.push.apply(ret, contextLines(lines.slice(0, contextSize)));
+                if (lines.length <= 4) {
+                  eofNL(ret, i, current);
+                }
+
+                oldRangeStart = 0;  newRangeStart = 0; curRange = [];
+              }
+            }
+            oldLine += lines.length;
+            newLine += lines.length;
+          }
+        }
+
+        return ret.join('\n') + '\n';
+      },
+
+      applyPatch: function(oldStr, uniDiff) {
+        var diffstr = uniDiff.split('\n');
+        var diff = [];
+        var remEOFNL = false,
+            addEOFNL = false;
+
+        for (var i = (diffstr[0][0]==='I'?4:0); i < diffstr.length; i++) {
+          if(diffstr[i][0] === '@') {
+            var meh = diffstr[i].split(/@@ -(\d+),(\d+) \+(\d+),(\d+) @@/);
+            diff.unshift({
+              start:meh[3],
+              oldlength:meh[2],
+              oldlines:[],
+              newlength:meh[4],
+              newlines:[]
+            });
+          } else if(diffstr[i][0] === '+') {
+            diff[0].newlines.push(diffstr[i].substr(1));
+          } else if(diffstr[i][0] === '-') {
+            diff[0].oldlines.push(diffstr[i].substr(1));
+          } else if(diffstr[i][0] === ' ') {
+            diff[0].newlines.push(diffstr[i].substr(1));
+            diff[0].oldlines.push(diffstr[i].substr(1));
+          } else if(diffstr[i][0] === '\\') {
+            if (diffstr[i-1][0] === '+') {
+              remEOFNL = true;
+            } else if(diffstr[i-1][0] === '-') {
+              addEOFNL = true;
+            }
+          }
+        }
+
+        var str = oldStr.split('\n');
+        for (var i = diff.length - 1; i >= 0; i--) {
+          var d = diff[i];
+          for (var j = 0; j < d.oldlength; j++) {
+            if(str[d.start-1+j] !== d.oldlines[j]) {
+              return false;
+            }
+          }
+          Array.prototype.splice.apply(str,[d.start-1,+d.oldlength].concat(d.newlines));
+        }
+
+        if (remEOFNL) {
+          while (!str[str.length-1]) {
+            str.pop();
+          }
+        } else if (addEOFNL) {
+          str.push('');
+        }
+        return str.join('\n');
+      },
+
+      convertChangesToXML: function(changes){
+        var ret = [];
+        for ( var i = 0; i < changes.length; i++) {
+          var change = changes[i];
+          if (change.added) {
+            ret.push('<ins>');
+          } else if (change.removed) {
+            ret.push('<del>');
+          }
+
+          ret.push(escapeHTML(change.value));
+
+          if (change.added) {
+            ret.push('</ins>');
+          } else if (change.removed) {
+            ret.push('</del>');
+          }
+        }
+        return ret.join('');
+      },
+
+      // See: http://code.google.com/p/google-diff-match-patch/wiki/API
+      convertChangesToDMP: function(changes){
+        var ret = [], change;
+        for ( var i = 0; i < changes.length; i++) {
+          change = changes[i];
+          ret.push([(change.added ? 1 : change.removed ? -1 : 0), change.value]);
+        }
+        return ret;
+      }
+    };
+  })();
+
+  if (typeof module !== 'undefined') {
+      module.exports = JsDiff;
+  }
+  else if (typeof define === 'function') {
+    define([], function() { return JsDiff; });
+  }
+  else if (typeof global.JsDiff === 'undefined') {
+    global.JsDiff = JsDiff;
+  }
+})(this);
+
+},{}],25:[function(require,module,exports){
+// intentionally commented out as it makes it slower...
+//'use strict';
+
+var arr = [];
+
+module.exports = function (a, b) {
+	if (a === b) {
+		return 0;
+	}
+
+	var aLen = a.length;
+	var bLen = b.length;
+
+	if (aLen === 0) {
+		return b.length;
+	}
+
+	if (bLen === 0) {
+		return a.length;
+	}
+
+	var bCharCode;
+	var ret;
+	var tmp;
+	var tmp2;
+	var i = 0;
+	var j = 0;
+
+	while (i < aLen) {
+		arr[i] = ++i;
+	}
+
+	while (j < bLen) {
+		bCharCode = b.charCodeAt(j);
+		tmp = j++;
+		ret = j;
+
+		for (i = 0; i < aLen; i++) {
+			tmp2 = bCharCode === a.charCodeAt(i) ? tmp : tmp + 1;
+			tmp = arr[i];
+			ret = arr[i] = tmp > ret ? tmp2 > ret ? ret + 1 : tmp2 : tmp2 > tmp ? tmp + 1 : tmp2;
+		}
+	}
+
+	return ret;
+};
+
+},{}],26:[function(require,module,exports){
+var utils = require(36);
+var TextSerializer = require(30);
+var colorDiff = require(40);
+var rgbRegexp = require(34);
+var themeMapper = require(35);
+
+var cacheSize = 0;
+var maxColorCacheSize = 1024;
+
+var ansiStyles = utils.extend({}, require(37));
+Object.keys(ansiStyles).forEach(function (styleName) {
+    ansiStyles[styleName.toLowerCase()] = ansiStyles[styleName];
+});
+
+function AnsiSerializer(theme) {
+    this.theme = theme;
+}
+
+AnsiSerializer.prototype = new TextSerializer();
+
+AnsiSerializer.prototype.format = 'ansi';
+
+var colorPalettes = {
+    16: {
+        '#000000': 'black',
+        '#ff0000': 'red',
+        '#00ff00': 'green',
+        '#ffff00': 'yellow',
+        '#0000ff': 'blue',
+        '#ff00ff': 'magenta',
+        '#00ffff': 'cyan',
+        '#ffffff': 'white',
+        '#808080': 'gray'
+    },
+    256: {}
+};
+
+var diffPalettes = {};
+
+function convertColorToObject(color) {
+    if (color.length < 6) {
+        // Allow CSS shorthand
+        color = color.replace(/^#?([0-9a-f])([0-9a-f])([0-9a-f])$/i, '$1$1$2$2$3$3');
+    }
+    // Split color into red, green, and blue components
+    var hexMatch = color.match(/^#?([0-9a-f][0-9a-f])([0-9a-f][0-9a-f])([0-9a-f][0-9a-f])$/i);
+    if (hexMatch) {
+        return {
+            R: parseInt(hexMatch[1], 16),
+            G: parseInt(hexMatch[2], 16),
+            B: parseInt(hexMatch[3], 16)
+        };
+    }
+}
+
+function toHexColor(colorObject) {
+    var hexString = (Math.round(colorObject.R) * 0x10000 + Math.round(colorObject.G) * 0x100 + Math.round(colorObject.B)).toString(16);
+    return '#' + ('00000'.substr(0, 6 - hexString.length)) + hexString;
+}
+
+function firstUp(text) {
+    return text.substring(0, 1).toUpperCase() + text.substring(1);
+}
+
+diffPalettes[16] = Object.keys(colorPalettes[16]).map(convertColorToObject);
+diffPalettes['bg16'] = Object.keys(colorPalettes[16]).filter(function (color) {
+    return color !== "#808080";
+}).map(convertColorToObject);
+diffPalettes[256] = [].concat(diffPalettes[16]);
+var nextAnsiColorNumber = 16;
+function registerNext256PaletteEntry(obj) {
+    diffPalettes[256].push(obj);
+    colorPalettes[256][toHexColor(obj)] = nextAnsiColorNumber;
+    nextAnsiColorNumber += 1;
+}
+
+for (var r = 0 ; r < 6 ; r += 1) {
+    for (var g = 0 ; g < 6 ; g += 1) {
+        for (var b = 0 ; b < 6 ; b += 1) {
+            registerNext256PaletteEntry({
+                R: Math.round(r * 256 / 6),
+                G: Math.round(g * 256 / 6),
+                B: Math.round(b * 256 / 6)
+            });
+        }
+    }
+}
+
+[
+    0x08, 0x12, 0x1c, 0x26, 0x30, 0x3a, 0x44, 0x4e, 0x58, 0x60, 0x66, 0x76,
+    0x80, 0x8a, 0x94, 0x9e, 0xa8, 0xb2, 0xbc, 0xc6, 0xd0, 0xda, 0xe4, 0xee
+].forEach(function (value) {
+    registerNext256PaletteEntry({R: value, G: value, B: value});
+});
+
+AnsiSerializer.prototype.text = function (options) {
+    var content = String(options.content);
+    if (content === '') {
+        return '';
+    }
+
+    var styles = themeMapper(this.theme, options.styles);
+
+    if (styles.length > 0) {
+        for (var i = styles.length -1; i >= 0; i -= 1) {
+            var styleName = styles[i];
+
+            if (ansiStyles[styleName]) {
+                content = ansiStyles[styleName].open + content + ansiStyles[styleName].close;
+            } else if (rgbRegexp.test(styleName)) {
+                var originalStyleName = styleName;
+                var isBackgroundColor = styleName.substring(0, 2) === 'bg';
+                var colorName = isBackgroundColor ? styleName.substring(2) : styleName;
+
+                var color16Hex = toHexColor(colorDiff.closest(convertColorToObject(colorName),
+                                                              diffPalettes[isBackgroundColor ? 'bg16' : 16]));
+                var closestColor16 = colorPalettes[16][color16Hex];
+
+                var color256Hex = toHexColor(colorDiff.closest(convertColorToObject(colorName), diffPalettes[256]));
+                var closest256ColorIndex = colorPalettes[256][color256Hex];
+
+                if (isBackgroundColor) {
+                    styleName = 'bg' + firstUp(closestColor16);
+                } else {
+                    styleName = closestColor16;
+                }
+
+                var open = ansiStyles[styleName].open;
+                var close = ansiStyles[styleName].close;
+                if (color16Hex !== color256Hex) {
+                    open += '\x1b[' + (isBackgroundColor ? 48 : 38) + ';5;' + closest256ColorIndex + 'm';
+                }
+                if (cacheSize < maxColorCacheSize) {
+                    ansiStyles[originalStyleName] = {open: open, close: close};
+                    cacheSize += 1;
+                }
+
+                content = open + content + close;
+            }
+        }
+    }
+
+    return content;
+};
+
+module.exports = AnsiSerializer;
+
+},{}],27:[function(require,module,exports){
+var cssStyles = require(31);
+var flattenBlocksInLines = require(33);
+var rgbRegexp = require(34);
+var themeMapper = require(35);
+
+function ColoredConsoleSerializer(theme) {
+    this.theme = theme;
+}
+
+ColoredConsoleSerializer.prototype.format = 'coloredConsole';
+
+ColoredConsoleSerializer.prototype.serialize = function (lines) {
+    var formatString = '';
+    var styleStrings = [];
+    this.serializeLines(flattenBlocksInLines(lines)).forEach(function (entry) {
+        if (entry) {
+            formatString += entry[0];
+            if (entry.length > 1) {
+                styleStrings.push(entry[1]);
+            }
+        }
+    });
+    return [formatString].concat(styleStrings);
+};
+
+ColoredConsoleSerializer.prototype.serializeLines = function (lines) {
+    var result = [];
+    lines.forEach(function (line, i) {
+        if (i > 0) {
+            result.push(['%c\n ', '']);
+        }
+        Array.prototype.push.apply(result, this.serializeLine(line));
+    }, this);
+    return result;
+};
+
+ColoredConsoleSerializer.prototype.serializeLine = function (line) {
+    var result = [];
+    line.forEach(function (outputEntry) {
+        if (this[outputEntry.style]) {
+            result.push(this[outputEntry.style](outputEntry.args));
+        }
+    }, this);
+    return result;
+};
+
+ColoredConsoleSerializer.prototype.block = function (content) {
+    return this.serializeLines(content);
+};
+
+ColoredConsoleSerializer.prototype.text = function (options) {
+    var content = String(options.content);
+    if (content === '') {
+        return '';
+    }
+
+    var styles = themeMapper(this.theme, options.styles);
+
+    var result = ['%c' + content.replace(/%/g, '%%')];
+    var styleProperties = [];
+
+    if (styles.length > 0) {
+        for (var i = 0; i < styles.length; i += 1) {
+            var styleName = styles[i];
+            if (rgbRegexp.test(styleName)) {
+                if (styleName.substring(0, 2) === 'bg') {
+                    styleProperties.push('background-color: ' + styleName.substring(2));
+                } else {
+                    styleProperties.push('color: ' + styleName);
+                }
+            } else if (cssStyles[styleName]) {
+                styleProperties.push(cssStyles[styleName]);
+            }
+        }
+    }
+    result.push(styleProperties.join('; '));
+    return result;
+};
+
+ColoredConsoleSerializer.prototype.raw = function (options) {
+    return String(options.content(this));
+};
+
+module.exports = ColoredConsoleSerializer;
+
+},{}],28:[function(require,module,exports){
+var cssStyles = require(31);
+var rgbRegexp = require(34);
+var themeMapper = require(35);
+
+function HtmlSerializer(theme) {
+    this.theme = theme;
+}
+
+HtmlSerializer.prototype.format = 'html';
+
+HtmlSerializer.prototype.serialize = function (lines) {
+    return '<div style="font-family: monospace; white-space: nowrap">\n' + this.serializeLines(lines) + '\n</div>';
+};
+
+HtmlSerializer.prototype.serializeLines = function (lines) {
+    return lines.map(function (line) {
+        return '  <div>' + (this.serializeLine(line).join('') || '&nbsp;') + '</div>';
+    }, this).join('\n');
+};
+
+HtmlSerializer.prototype.serializeLine = function (line) {
+    return line.map(function (outputEntry) {
+        return this[outputEntry.style] ?
+            this[outputEntry.style](outputEntry.args) :
+            '';
+    }, this);
+};
+
+HtmlSerializer.prototype.block = function (content) {
+    return '<div style="display: inline-block; vertical-align: top">\n' +
+        this.serializeLines(content) +
+        '\n</div>';
+};
+
+HtmlSerializer.prototype.text = function (options) {
+    var content = String(options.content);
+
+    if (content === '') {
+        return '';
+    }
+
+    content = content
+        .replace(/&/g, '&amp;')
+        .replace(/ /g, '&nbsp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+
+
+    var styles = themeMapper(this.theme, options.styles);
+
+    if (styles.length > 0) {
+        var styleProperties = [];
+        for (var j = 0; j < styles.length; j += 1) {
+            var styleName = styles[j];
+            if (rgbRegexp.test(styleName)) {
+                if (styleName.substring(0, 2) === 'bg') {
+                    styleProperties.push('background-color: ' + styleName.substring(2));
+                } else {
+                    styleProperties.push('color: ' + styleName);
+                }
+            } else if (cssStyles[styleName]) {
+                styleProperties.push(cssStyles[styleName]);
+            }
+
+        }
+
+        if (styleProperties.length > 0) {
+            content = '<span style="' + styleProperties.join('; ') + '">' + content + '</span>';
+        }
+    }
+    return content;
+};
+
+HtmlSerializer.prototype.raw = function (options) {
+    return String(options.content(this));
+};
+
+module.exports = HtmlSerializer;
+
+},{}],29:[function(require,module,exports){
+(function (process){
+/*global window*/
+var utils = require(36);
+var extend = utils.extend;
+var duplicateText = require(32);
+var rgbRegexp = require(34);
+var cssStyles = require(31);
+
+function MagicPen(options) {
+    if (!(this instanceof MagicPen)) {
+        return new MagicPen(options);
+    }
+
+    options = options || {};
+
+    if (typeof options === "string") {
+        options = {format: options };
+    }
+
+    var indentationWidth = 'indentationWidth' in options ?
+        options.indentationWidth : 2;
+    this.indentationWidth = Math.max(indentationWidth, 0);
+
+    this.indentationLevel = 0;
+    this.output = [[]];
+    this.styles = Object.create(null);
+    this.installedPlugins = [];
+    this._themes = {};
+    this.preferredWidth = (!process.browser && process.stdout.columns) || 80;
+    if (options.format) {
+        this.format = options.format;
+    }
+}
+
+if (typeof window !== 'undefined' && typeof window.navigator !== 'undefined') {
+    if (window.mochaPhantomJS || (window.__karma__ && window.__karma__.config.captureConsole)) {
+        MagicPen.defaultFormat = 'ansi'; // colored console
+    } else {
+        MagicPen.defaultFormat = 'html'; // Browser
+    }
+} else if (require(42)) {
+    MagicPen.defaultFormat = 'ansi'; // colored console
+} else {
+    MagicPen.defaultFormat = 'text'; // Plain text
+}
+
+MagicPen.prototype.newline = MagicPen.prototype.nl = function (count) {
+    if (typeof count === 'undefined') {
+        count = 1;
+    }
+
+    if (count === 0) {
+        return this;
+    }
+
+    for (var i = 0; i < count; i += 1) {
+        this.output.push([]);
+    }
+    return this;
+};
+
+MagicPen.serializers = {};
+[
+    require(30),
+    require(28),
+    require(26),
+    require(27)
+].forEach(function (serializer) {
+    MagicPen.serializers[serializer.prototype.format] = serializer;
+});
+
+function hasSameTextStyling(a, b) {
+    if (!a || !b || a.style !== 'text' || b.style !== 'text') {
+        return false;
+    }
+
+    return utils.arrayEquals(a.args.styles, b.args.styles);
+}
+
+function normalizeLine(line) {
+    if (line.length === 0) {
+        return line;
+    }
+
+    var result = [line[0]];
+    for (var i = 1; i < line.length; i += 1) {
+        var lastEntry = result[result.length - 1];
+        var entry = line[i];
+        if (entry.style === 'text' && entry.args.content === '') {
+            continue;
+        }
+
+        if (hasSameTextStyling(lastEntry, entry)) {
+            result[result.length - 1] = {
+                style: lastEntry.style,
+                args: {
+                    content: lastEntry.args.content + entry.args.content,
+                    styles: lastEntry.args.styles
+                }
+            };
+        } else {
+            result.push(entry);
+        }
+    }
+
+    return result;
+}
+
+MagicPen.prototype.write = function (options) {
+    if (this.styles[options.style]) {
+        this.styles[options.style].apply(this, options.args);
+        return this;
+    }
+    var lastLine = this.output[this.output.length - 1];
+    var lastEntry = lastLine[lastLine.length - 1];
+    if (hasSameTextStyling(lastEntry, options)) {
+        lastLine[lastLine.length - 1] = {
+            style: lastEntry.style,
+            args: {
+                content: lastEntry.args.content + options.args.content,
+                styles: lastEntry.args.styles
+            }
+        };
+    } else {
+        lastLine.push(options);
+    }
+
+    return this;
+};
+
+MagicPen.prototype.indentLines = function () {
+    this.indentationLevel += 1;
+    return this;
+};
+
+MagicPen.prototype.indent = MagicPen.prototype.i = function () {
+    for (var i = 0; i < this.indentationLevel; i += 1) {
+        this.space(this.indentationWidth);
+    }
+    return this;
+};
+
+MagicPen.prototype.outdentLines = function () {
+    this.indentationLevel = Math.max(0, this.indentationLevel - 1);
+    return this;
+};
+
+MagicPen.prototype.addStyle = function (style, handler, allowRedefinition) {
+    if (this[style] && !allowRedefinition) {
+        throw new Error('"' + style + '" style is already defined, set 3rd arg (allowRedefinition) to true to define it anyway');
+    }
+
+    var styles = this.styles;
+    this.styles = Object.create(null);
+    for (var p in styles) {
+        this.styles[p] = styles[p];
+    }
+
+    this.styles[style] = handler;
+    this[style] = function () {
+        handler.apply(this, arguments);
+        return this;
+    };
+    return this;
+};
+
+MagicPen.prototype.toString = function (format) {
+    if (format && this.format && format !== this.format) {
+        throw new Error('A pen with format: ' + this.format + ' cannot be serialized to: ' + format);
+    }
+
+    format = this.format || format || 'text';
+    if (format === 'auto') {
+        format = MagicPen.defaultFormat;
+    }
+    var theme = this._themes[format] || {};
+    var serializer = new MagicPen.serializers[format](theme);
+    return serializer.serialize(this.output);
+};
+
+MagicPen.prototype.text = function () {
+    var content = arguments[0];
+    if (content === '') {
+        return this;
+    }
+
+    var styles = new Array(arguments.length - 1);
+    for (var i = 1; i < arguments.length; i += 1) {
+        styles[i - 1] = arguments[i];
+    }
+    content = String(content);
+    if (content.indexOf('\n') !== -1) {
+        var lines = content.split(/\n/);
+        lines.forEach(function (lineContent, index) {
+            if (lineContent.length) {
+                this.write({
+                    style: 'text',
+                    args: { content: lineContent, styles: styles }
+                });
+            }
+            if (index < lines.length - 1) {
+                this.nl();
+            }
+        }, this);
+        return this;
+    } else {
+        return this.write({
+            style: 'text',
+            args: { content: content, styles: styles }
+        });
+    }
+};
+
+MagicPen.prototype.removeFormatting = function () {
+    var result = this.clone();
+    this.output.forEach(function (line, index) {
+        result.output[index] = normalizeLine(line.map(function (outputEntry) {
+            return outputEntry.style === 'text' ?
+                { style: 'text', args: { content: outputEntry.args.content, styles: [] } } :
+                outputEntry;
+        }));
+    });
+    result.indentationLevel = this.indentationLevel;
+    return result;
+};
+
+MagicPen.prototype.getContentFromArguments = function (args) {
+    var clone;
+    if (args[0].isMagicPen) {
+        this.ensureCompatibleFormat(args[0].format);
+        return args[0];
+    } else if (typeof args[0] === 'function') {
+        clone = this.clone();
+        args[0].call(clone, clone);
+        return clone;
+    } else if (typeof args[0] === 'string' && args.length === 1) {
+        clone = this.clone();
+        clone.text(args[0]);
+        return clone;
+    } else if (typeof args[0] === 'string') {
+        clone = this.clone();
+        clone[args[0]].apply(clone, Array.prototype.slice.call(args, 1));
+        return clone;
+    } else {
+        throw new Error('Requires the arguments to be:\n' +
+                        'a pen or\n' +
+                        'a callback appending content to a pen or\n' +
+                        'a style and arguments for that style or\n' +
+                        'just a string.');
+    }
+};
+
+MagicPen.prototype.isMultiline = function () {
+    return this.output.length > 1 || this.size().height > 1;
+};
+
+MagicPen.prototype.isBlock = function () {
+    return this.output.length === 1 &&
+        this.output[0].length === 1 &&
+        this.output[0][0].style === 'block';
+};
+
+MagicPen.prototype.ensureCompatibleFormat = function (format) {
+    if (format && this.format && format !== this.format) {
+        throw new Error('This pen is only compatible with the format: ' + this.format);
+    }
+};
+
+MagicPen.prototype.block = function () {
+    var pen = this.getContentFromArguments(arguments);
+
+    var blockOutput = pen.output.map(function (line) {
+        return [].concat(line);
+    });
+    return this.write({ style: 'block', args: blockOutput });
+};
+function isRawOutput(options) {
+    return options &&
+        typeof options === 'object' &&
+        typeof options.width === 'number' &&
+        typeof options.height === 'number' && (
+            typeof options.content === 'function' ||
+                typeof options.content === 'string'
+        );
+}
+
+MagicPen.prototype.alt = function (options) {
+    var format = this.format;
+    if (!format) {
+        throw new Error('The alt method is only supported on pen where the format has already been set');
+    }
+
+    var outputProperty = options[format];
+
+    if (typeof outputProperty === 'undefined') {
+        if (options.fallback) {
+            return this.append(options.fallback);
+        } else {
+            throw new Error('Output is not specified for format: ' + format + ' and no fallback method is given');
+        }
+    }
+
+    if (typeof outputProperty === 'string' || isRawOutput(outputProperty)) {
+        return this.raw(outputProperty);
+    } else {
+        return this.append(outputProperty);
+    }
+};
+
+MagicPen.prototype.raw = function (options) {
+    var format = this.format;
+    if (!format) {
+        throw new Error('The alt method is only supported on pen where the format has already been set');
+    }
+
+    if (typeof options === 'string') {
+        return this.write({ style: 'raw', args: {
+            height: 0,
+            width: 0,
+            content: function () {
+                return options;
+            }
+        }});
+    }
+
+    if (isRawOutput(options)) {
+        if (typeof options.content === 'string') {
+            options = extend({}, options);
+            var content = options.content;
+            options.content = function () {
+                return content;
+            };
+        }
+
+        return this.write({ style: 'raw', args: options });
+    }
+
+    throw new Error('Raw ' + this.format + ' content needs to adhere to one of the following forms:\n' +
+                    'a string of raw content\n' +
+                    'a function returning a string of raw content or\n' +
+                    'an object with the following form { width: <number>, height: <number>, content: <string function() {}|string> }');
+};
+
+function amend(output, pen) {
+    var lastLine = output[output.length - 1].slice();
+    var newOutput = output.slice(0, -1);
+    var lastEntry = lastLine[lastLine.length - 1];
+    if (lastEntry && lastEntry.style === 'block') {
+        lastLine[lastLine.length - 1] = {
+            style: 'block',
+            args: amend(lastEntry.args, pen)
+        };
+        newOutput[output.length - 1] = lastLine;
+    } else {
+        Array.prototype.push.apply(lastLine, pen.output[0]);
+        newOutput[output.length - 1] = normalizeLine(lastLine);
+        newOutput.push.apply(newOutput, pen.output.slice(1));
+    }
+
+    return newOutput;
+}
+
+MagicPen.prototype.amend = function () {
+    var pen = this.getContentFromArguments(arguments);
+
+    if (pen.isEmpty()) {
+        return this;
+    }
+
+    this.output = amend(this.output, pen);
+
+    return this;
+};
+
+MagicPen.prototype.append = function () {
+    var pen = this.getContentFromArguments(arguments);
+
+    if (pen.isEmpty()) {
+        return this;
+    }
+
+    var lastLine = this.output[this.output.length - 1];
+    Array.prototype.push.apply(lastLine, pen.output[0]);
+    this.output[this.output.length - 1] = normalizeLine(lastLine);
+
+    this.output.push.apply(this.output, pen.output.slice(1));
+
+    return this;
+};
+
+MagicPen.prototype.prependLinesWith = function () {
+    var pen = this.getContentFromArguments(arguments);
+
+    if (pen.isEmpty()) {
+        return this;
+    }
+
+    if (pen.output.length > 1) {
+        throw new Error('PrependLinesWith only supports a pen with single line content');
+    }
+
+    var height = this.size().height;
+    var output = this.clone();
+    output.block(function () {
+        for (var i = 0; i < height; i += 1) {
+            if (0 < i) {
+                this.nl();
+            }
+            this.append(pen);
+        }
+    });
+    output.block(this);
+
+    this.output = output.output;
+    return this;
+};
+
+MagicPen.prototype.space = MagicPen.prototype.sp = function (count) {
+    if (count === 0) {
+        return this;
+    }
+
+    if (typeof count === 'undefined') {
+        count = 1;
+    }
+
+    return this.text(duplicateText(' ', count));
+};
+
+[
+    'bold', 'dim', 'italic', 'underline', 'inverse', 'hidden',
+    'strikeThrough', 'black', 'red', 'green', 'yellow', 'blue',
+    'magenta', 'cyan', 'white', 'gray', 'bgBlack', 'bgRed',
+    'bgGreen', 'bgYellow', 'bgBlue', 'bgMagenta', 'bgCyan',
+    'bgWhite'
+].forEach(function (textStyle) {
+    MagicPen.prototype[textStyle] = MagicPen.prototype[textStyle.toLowerCase()] = function (content) {
+        return this.text(content, textStyle);
+    };
+});
+
+MagicPen.prototype.clone = function (format) {
+    this.ensureCompatibleFormat(format);
+
+    function MagicPenClone() {}
+    MagicPenClone.prototype = this;
+    var clonedPen = new MagicPenClone();
+    clonedPen.styles = this.styles;
+    clonedPen.indentationLevel = 0;
+    clonedPen.output = [[]];
+    clonedPen.installedPlugins = this.installedPlugins;
+    clonedPen._themes = this._themes;
+    clonedPen.format = format || this.format;
+    return clonedPen;
+};
+
+MagicPen.prototype.isMagicPen = true;
+
+MagicPen.prototype.size = function () {
+    return utils.calculateSize(this.output);
+};
+
+MagicPen.prototype.installPlugin = function (plugin) {
+    var alreadyInstalled = this.installedPlugins.some(function (installedPlugin) {
+        return installedPlugin === plugin.name;
+    });
+
+    if (alreadyInstalled) {
+        return;
+    }
+
+    if (typeof plugin !== 'object' ||
+        typeof plugin.name !== 'string' ||
+        typeof plugin.installInto !== 'function' ||
+        (plugin.dependencies && !Array.isArray(plugin.dependencies))) {
+        throw new Error('Plugins must adhere to the following interface\n' +
+                        '{\n' +
+                        '  name: <plugin name>,\n' +
+                        '  dependencies: <an optional list of dependencies>,\n' +
+                        '  installInto: <a function that will update the given magicpen instance>\n' +
+                        '}');
+    }
+
+    if (plugin.dependencies) {
+        var installedPlugins = this.installedPlugins;
+        var unfulfilledDependencies = plugin.dependencies.filter(function (dependency) {
+            return !installedPlugins.some(function (plugin) {
+                return plugin === dependency;
+            });
+        });
+
+        if (unfulfilledDependencies.length === 1) {
+            throw new Error(plugin.name + ' requires plugin ' + unfulfilledDependencies[0]);
+        } else if (unfulfilledDependencies.length > 1) {
+            throw new Error(plugin.name + ' requires plugins ' +
+                            unfulfilledDependencies.slice(0, -1).join(', ') +
+                            ' and ' + unfulfilledDependencies[unfulfilledDependencies.length - 1]);
+        }
+    }
+
+    this.installedPlugins = this.installedPlugins.slice();
+    this.installedPlugins.push(plugin.name);
+    plugin.installInto(this);
+
+    return this; // for chaining
+};
+
+function replaceText(output, outputArray, regexp, cb) {
+    var replacedOutput = output;
+    outputArray.forEach(function (line, i) {
+        if (0 < i) {
+            replacedOutput.nl();
+        }
+
+        line.forEach(function (outputEntry, j) {
+            if (outputEntry.style === 'block') {
+                return replacedOutput.output[replacedOutput.output.length - 1].push({
+                    style: 'block',
+                    args: replaceText(output.clone(), outputEntry.args, regexp, cb)
+                });
+            } else if (outputEntry.style !== 'text') {
+                return replacedOutput.output[replacedOutput.output.length - 1].push(outputEntry);
+            }
+
+            if (regexp.global) {
+                regexp.lastIndex = 0;
+            }
+            var m;
+            var first = true;
+            var lastIndex = 0;
+            var text = outputEntry.args.content;
+            var styles = outputEntry.args.styles;
+            while ((m = regexp.exec(text)) !== null && (regexp.global || first)) {
+                if (lastIndex < m.index) {
+                    replacedOutput.text.apply(replacedOutput, [text.substring(lastIndex, m.index)].concat(styles));
+                }
+
+                cb.apply(replacedOutput, [styles].concat(m));
+                first = false;
+                lastIndex = m.index + m[0].length;
+            }
+
+            if (lastIndex === 0) {
+                var lastLine;
+                if (replacedOutput.output.length === 0) {
+                    lastLine = replacedOutput.output[0] = [];
+                } else {
+                    lastLine = replacedOutput.output[replacedOutput.output.length - 1];
+                }
+
+                lastLine.push(outputEntry);
+            } else if (lastIndex < text.length) {
+                replacedOutput.text.apply(replacedOutput, [text.substring(lastIndex, text.length)].concat(styles));
+            }
+        }, this);
+    }, this);
+
+    return replacedOutput.output.map(normalizeLine);
+}
+
+MagicPen.prototype.isEmpty = function () {
+    return this.output.length === 1 && this.output[0].length === 0;
+};
+
+MagicPen.prototype.replaceText = function (regexp, cb) {
+    if (this.isEmpty()) {
+        return this;
+    }
+
+    if (typeof regexp === 'string') {
+        regexp = new RegExp(utils.escapeRegExp(regexp), 'g');
+    }
+
+    if (typeof cb === 'string') {
+        var text = cb;
+        cb = function (styles, _) {
+            var args = [text].concat(styles);
+            this.text.apply(this, args);
+        };
+    }
+
+
+    if (arguments.length === 1) {
+        cb = regexp;
+        regexp = /.*/;
+    }
+
+    this.output = replaceText(this.clone(), this.output, regexp, cb);
+
+    return this;
+};
+
+MagicPen.prototype.installTheme = function (formats, theme) {
+    var that = this;
+    if (arguments.length === 1) {
+        theme = formats;
+        formats = Object.keys(MagicPen.serializers);
+    }
+
+    if (typeof formats === 'string') {
+        formats = [formats];
+    }
+
+    if (
+        typeof theme !== 'object' ||
+        !Array.isArray(formats) ||
+        formats.some(function (format) {
+            return typeof format !== 'string';
+        })
+    ) {
+        throw new Error("Themes must be installed the following way:\n" +
+                        "Install theme for all formats: pen.installTheme({ comment: 'gray' })\n" +
+                        "Install theme for a specific format: pen.installTheme('ansi', { comment: 'gray' }) or\n" +
+                        "Install theme for a list of formats: pen.installTheme(['ansi', 'html'], { comment: 'gray' })");
+    }
+
+    Object.keys(theme).forEach(function (themeKey) {
+        if (rgbRegexp.test(themeKey) || cssStyles[themeKey]) {
+            throw new Error("Invalid theme key: '" + themeKey + "' you can't map build styles.");
+        }
+
+        if (!that[themeKey]) {
+            that.addStyle(themeKey, function (content) {
+                this.text(content, themeKey);
+            });
+        }
+    });
+
+    that._themes = extend({}, that._themes);
+    formats.forEach(function (format) {
+        that._themes[format] = extend({}, that._themes[format] || {}, theme);
+    });
+
+
+    return this;
+};
+
+module.exports = MagicPen;
+
+}).call(this,require(23))
+},{}],30:[function(require,module,exports){
+var flattenBlocksInLines = require(33);
+
+function TextSerializer() {}
+
+TextSerializer.prototype.format = 'text';
+
+TextSerializer.prototype.serialize = function (lines) {
+    lines = flattenBlocksInLines(lines);
+    return lines.map(this.serializeLine, this).join('\n');
+};
+
+TextSerializer.prototype.serializeLine = function (line) {
+    return line.map(function (outputEntry) {
+        return this[outputEntry.style] ?
+            String(this[outputEntry.style](outputEntry.args)) :
+            '';
+    }, this).join('');
+};
+
+TextSerializer.prototype.text = function (options) {
+    return String(options.content);
+};
+
+TextSerializer.prototype.block = function (content) {
+    return this.serialize(content);
+};
+
+TextSerializer.prototype.raw = function (options) {
+    return String(options.content(this));
+};
+
+
+module.exports = TextSerializer;
+
+},{}],31:[function(require,module,exports){
+var cssStyles = {
+    bold: 'font-weight: bold',
+    dim: 'opacity: 0.7',
+    italic: 'font-style: italic',
+    underline: 'text-decoration: underline',
+    inverse: '-webkit-filter: invert(%100); filter: invert(100%)',
+    hidden: 'visibility: hidden',
+    strikeThrough: 'text-decoration: line-through',
+
+    black: 'color: black',
+    red: 'color: red',
+    green: 'color: green',
+    yellow: 'color: yellow',
+    blue: 'color: blue',
+    magenta: 'color: magenta',
+    cyan: 'color: cyan',
+    white: 'color: white',
+    gray: 'color: gray',
+
+    bgBlack: 'background-color: black',
+    bgRed: 'background-color: red',
+    bgGreen: 'background-color: green',
+    bgYellow: 'background-color: yellow',
+    bgBlue: 'background-color: blue',
+    bgMagenta: 'background-color: magenta',
+    bgCyan: 'background-color: cyan',
+    bgWhite: 'background-color: white'
+};
+
+Object.keys(cssStyles).forEach(function (styleName) {
+    cssStyles[styleName.toLowerCase()] = cssStyles[styleName];
+});
+
+module.exports = cssStyles;
+
+},{}],32:[function(require,module,exports){
+var whitespaceCacheLength = 256;
+var whitespaceCache = [''];
+for (var i = 1; i <= whitespaceCacheLength; i += 1) {
+    whitespaceCache[i] = whitespaceCache[i - 1] + ' ';
+}
+
+function duplicateText(content, times) {
+    if (times < 0) {
+        return '';
+    }
+
+    var result = '';
+
+    if (content === ' ') {
+        if (times <= whitespaceCacheLength) {
+            return whitespaceCache[times];
+        }
+
+        var segment = whitespaceCache[whitespaceCacheLength];
+        var numberOfSegments = Math.floor(times / whitespaceCacheLength);
+        for (var i = 0; i < numberOfSegments; i += 1) {
+            result += segment;
+        }
+        result += whitespaceCache[times % whitespaceCacheLength];
+    } else {
+        for (var j = 0; j < times; j += 1) {
+            result += content;
+        }
+    }
+
+    return result;
+}
+
+module.exports = duplicateText;
+
+},{}],33:[function(require,module,exports){
+var utils = require(36);
+var duplicateText = require(32);
+
+function createPadding(length) {
+    return { style: 'text', args: { content: duplicateText(' ', length), styles: [] } };
+}
+
+function lineContainsBlocks(line) {
+    return line.some(function (outputEntry) {
+        return outputEntry.style === 'block' ||
+            (outputEntry.style === 'text' && String(outputEntry.args.content).indexOf('\n') !== -1);
+    });
+}
+
+function flattenBlocksInOutputEntry(outputEntry) {
+    switch (outputEntry.style) {
+    case 'text': return String(outputEntry.args.content).split('\n').map(function (line) {
+        if (line === '') {
+            return [];
+        }
+
+        var args = { content: line, styles: outputEntry.args.styles };
+        return [{ style: 'text', args: args }];
+    });
+    case 'block': return flattenBlocksInLines(outputEntry.args);
+    default: return [];
+    }
+}
+
+function flattenBlocksInLine(line) {
+    if (line.length === 0) {
+       return [[]];
+    }
+
+    if (!lineContainsBlocks(line)) {
+        return [line];
+    }
+
+    var result = [];
+    var linesLengths = [];
+
+    var startIndex = 0;
+    line.forEach(function (outputEntry, blockIndex) {
+        var blockLines = flattenBlocksInOutputEntry(outputEntry);
+
+        var blockLinesLengths = blockLines.map(function (line) {
+            return utils.calculateLineSize(line).width;
+        });
+
+        var longestLineLength = Math.max.apply(null, blockLinesLengths);
+
+        blockLines.forEach(function (blockLine, index) {
+            var resultLine = result[index];
+
+            if (!resultLine) {
+                result[index] = resultLine = [];
+                linesLengths[index] = 0;
+            }
+
+            if (blockLine.length) {
+                var paddingLength = startIndex - linesLengths[index];
+                resultLine.push(createPadding(paddingLength));
+                Array.prototype.push.apply(resultLine, blockLine);
+                linesLengths[index] = startIndex + blockLinesLengths[index];
+            }
+        });
+
+        startIndex += longestLineLength;
+    }, this);
+    return result;
+}
+
+function flattenBlocksInLines(lines) {
+    var result = [];
+    lines.forEach(function (line) {
+        flattenBlocksInLine(line).forEach(function (line) {
+            result.push(line);
+        });
+    });
+    return result;
+}
+
+module.exports = flattenBlocksInLines;
+
+},{}],34:[function(require,module,exports){
+module.exports =  /^(?:bg)?#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+},{}],35:[function(require,module,exports){
+module.exports = function (theme, styles) {
+    if (styles.length === 1) {
+        var count = 0;
+        var stack = [];
+        var themeMapping = styles[0];
+        while(typeof themeMapping === 'string' && theme[themeMapping]) {
+            themeMapping = theme[themeMapping];
+            count += 1;
+            if (100 < count) {
+                var index = stack.indexOf(themeMapping);
+                stack.push(themeMapping);
+                if (index !== -1) {
+                    throw new Error('Your theme contains a loop: ' + stack.slice(index).join(' -> '));
+                }
+            }
+        }
+
+        return Array.isArray(themeMapping) ? themeMapping : [themeMapping];
+    }
+
+    return styles;
+};
+
+},{}],36:[function(require,module,exports){
+var utils = {
+    extend: function (target) {
+        for (var i = 1; i < arguments.length; i += 1) {
+            var source = arguments[i];
+            Object.keys(source).forEach(function (key) {
+                target[key] = source[key];
+            });
+        }
+        return target;
+    },
+
+    calculateOutputEntrySize: function (outputEntry) {
+        switch (outputEntry.style) {
+        case 'text':
+            return { width: String(outputEntry.args.content).length, height: 1 };
+        case 'block':
+            return utils.calculateSize(outputEntry.args);
+        case 'raw':
+            var arg = outputEntry.args;
+            return { width: arg.width, height: arg.height };
+        default: return { width: 0, height: 0 };
+        }
+    },
+
+    calculateLineSize: function (line) {
+        var size = { height: 1, width: 0 };
+        line.forEach(function (outputEntry) {
+            var outputEntrySize = utils.calculateOutputEntrySize(outputEntry);
+            size.width += outputEntrySize.width;
+            size.height = Math.max(outputEntrySize.height, size.height);
+        });
+        return size;
+    },
+
+    calculateSize: function (lines) {
+        var size = { height: 0, width: 0 };
+        lines.forEach(function (line) {
+            var lineSize = utils.calculateLineSize(line);
+            size.height += lineSize.height;
+            size.width = Math.max(size.width, lineSize.width);
+        });
+        return size;
+    },
+
+    arrayEquals: function (a, b) {
+        if (a === b) {
+            return true;
+        }
+
+        if (!a || a.length !== b.length) {
+            return false;
+        }
+
+        for (var i = 0; i < a.length; i += 1) {
+            if (a[i] !== b[i]) {
+                return false;
+            }
+        }
+
+        return true;
+
+    },
+
+    escapeRegExp: function (text){
+        return text.replace(/([.*+?^${}()|\[\]\/\\])/g, "\\$1");
+    }
+};
+
+module.exports = utils;
+
+},{}],37:[function(require,module,exports){
+'use strict';
+
+var styles = module.exports = {
+	modifiers: {
+		reset: [0, 0],
+		bold: [1, 22], // 21 isn't widely supported and 22 does the same thing
+		dim: [2, 22],
+		italic: [3, 23],
+		underline: [4, 24],
+		inverse: [7, 27],
+		hidden: [8, 28],
+		strikethrough: [9, 29]
+	},
+	colors: {
+		black: [30, 39],
+		red: [31, 39],
+		green: [32, 39],
+		yellow: [33, 39],
+		blue: [34, 39],
+		magenta: [35, 39],
+		cyan: [36, 39],
+		white: [37, 39],
+		gray: [90, 39]
+	},
+	bgColors: {
+		bgBlack: [40, 49],
+		bgRed: [41, 49],
+		bgGreen: [42, 49],
+		bgYellow: [43, 49],
+		bgBlue: [44, 49],
+		bgMagenta: [45, 49],
+		bgCyan: [46, 49],
+		bgWhite: [47, 49]
+	}
+};
+
+// fix humans
+styles.colors.grey = styles.colors.gray;
+
+Object.keys(styles).forEach(function (groupName) {
+	var group = styles[groupName];
+
+	Object.keys(group).forEach(function (styleName) {
+		var style = group[styleName];
+
+		styles[styleName] = group[styleName] = {
+			open: '\u001b[' + style[0] + 'm',
+			close: '\u001b[' + style[1] + 'm'
+		};
+	});
+
+	Object.defineProperty(styles, groupName, {
+		value: group,
+		enumerable: false
+	});
+});
+
+},{}],38:[function(require,module,exports){
+/**
+ * @author Markus Ekholm
+ * @copyright 2012-2015 (c) Markus Ekholm <markus at botten dot org >
+ * @license Copyright (c) 2012-2015, Markus Ekholm
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of the <organization> nor the
+ *      names of its contributors may be used to endorse or promote products
+ *      derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL MARKUS EKHOLM BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+* EXPORTS
+*/
+exports.rgb_to_lab = rgb_to_lab;
+
+/**
+* IMPORTS
+*/
+var pow  = Math.pow;
+var sqrt = Math.sqrt;
+
+/**
+ * API FUNCTIONS
+ */
+
+/**
+* Returns c converted to labcolor.
+* @param {rgbcolor} c should have fields R,G,B
+* @return {labcolor} c converted to labcolor
+*/
+function rgb_to_lab(c)
+{
+  return xyz_to_lab(rgb_to_xyz(c))
+}
+
+/**
+* Returns c converted to xyzcolor.
+* @param {rgbcolor} c should have fields R,G,B
+* @return {xyzcolor} c converted to xyzcolor
+*/
+function rgb_to_xyz(c)
+{
+  // Based on http://www.easyrgb.com/index.php?X=MATH&H=02
+  var R = ( c.R / 255 );
+  var G = ( c.G / 255 );
+  var B = ( c.B / 255 );
+
+  if ( R > 0.04045 ) R = pow(( ( R + 0.055 ) / 1.055 ),2.4);
+  else               R = R / 12.92;
+  if ( G > 0.04045 ) G = pow(( ( G + 0.055 ) / 1.055 ),2.4);
+  else               G = G / 12.92;
+  if ( B > 0.04045 ) B = pow(( ( B + 0.055 ) / 1.055 ), 2.4);
+  else               B = B / 12.92;
+
+  R *= 100;
+  G *= 100;
+  B *= 100;
+
+  // Observer. = 2°, Illuminant = D65
+  var X = R * 0.4124 + G * 0.3576 + B * 0.1805;
+  var Y = R * 0.2126 + G * 0.7152 + B * 0.0722;
+  var Z = R * 0.0193 + G * 0.1192 + B * 0.9505;
+  return {'X' : X, 'Y' : Y, 'Z' : Z};
+}
+
+/**
+* Returns c converted to labcolor.
+* @param {xyzcolor} c should have fields X,Y,Z
+* @return {labcolor} c converted to labcolor
+*/
+function xyz_to_lab(c)
+{
+  // Based on http://www.easyrgb.com/index.php?X=MATH&H=07
+  var ref_Y = 100.000;
+  var ref_Z = 108.883;
+  var ref_X = 95.047; // Observer= 2°, Illuminant= D65
+  var Y = c.Y / ref_Y;
+  var Z = c.Z / ref_Z;
+  var X = c.X / ref_X;
+  if ( X > 0.008856 ) X = pow(X, 1/3);
+  else                X = ( 7.787 * X ) + ( 16 / 116 );
+  if ( Y > 0.008856 ) Y = pow(Y, 1/3);
+  else                Y = ( 7.787 * Y ) + ( 16 / 116 );
+  if ( Z > 0.008856 ) Z = pow(Z, 1/3);
+  else                Z = ( 7.787 * Z ) + ( 16 / 116 );
+  var L = ( 116 * Y ) - 16;
+  var a = 500 * ( X - Y );
+  var b = 200 * ( Y - Z );
+  return {'L' : L , 'a' : a, 'b' : b};
+}
+
+// Local Variables:
+// allout-layout: t
+// js-indent-level: 2
+// End:
+
+},{}],39:[function(require,module,exports){
+/**
+ * @author Markus Ekholm
+ * @copyright 2012-2015 (c) Markus Ekholm <markus at botten dot org >
+ * @license Copyright (c) 2012-2015, Markus Ekholm
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of the <organization> nor the
+ *      names of its contributors may be used to endorse or promote products
+ *      derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL MARKUS EKHOLM BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+* EXPORTS
+*/
+exports.ciede2000 = ciede2000;
+
+/**
+* IMPORTS
+*/
+var sqrt = Math.sqrt;
+var pow = Math.pow;
+var cos = Math.cos;
+var atan2 = Math.atan2;
+var sin = Math.sin;
+var abs = Math.abs;
+var exp = Math.exp;
+var PI = Math.PI;
+
+/**
+ * API FUNCTIONS
+ */
+
+/**
+* Returns diff between c1 and c2 using the CIEDE2000 algorithm
+* @param {labcolor} c1    Should have fields L,a,b
+* @param {labcolor} c2    Should have fields L,a,b
+* @return {float}   Difference between c1 and c2
+*/
+function ciede2000(c1,c2)
+{
+  /**
+   * Implemented as in "The CIEDE2000 Color-Difference Formula:
+   * Implementation Notes, Supplementary Test Data, and Mathematical Observations"
+   * by Gaurav Sharma, Wencheng Wu and Edul N. Dalal.
+   */
+
+  // Get L,a,b values for color 1
+  var L1 = c1.L;
+  var a1 = c1.a;
+  var b1 = c1.b;
+
+  // Get L,a,b values for color 2
+  var L2 = c2.L;
+  var a2 = c2.a;
+  var b2 = c2.b;
+
+  // Weight factors
+  var kL = 1;
+  var kC = 1;
+  var kH = 1;
+
+  /**
+   * Step 1: Calculate C1p, C2p, h1p, h2p
+   */
+  var C1 = sqrt(pow(a1, 2) + pow(b1, 2)) //(2)
+  var C2 = sqrt(pow(a2, 2) + pow(b2, 2)) //(2)
+
+  var a_C1_C2 = (C1+C2)/2.0;             //(3)
+
+  var G = 0.5 * (1 - sqrt(pow(a_C1_C2 , 7.0) /
+                          (pow(a_C1_C2, 7.0) + pow(25.0, 7.0)))); //(4)
+
+  var a1p = (1.0 + G) * a1; //(5)
+  var a2p = (1.0 + G) * a2; //(5)
+
+  var C1p = sqrt(pow(a1p, 2) + pow(b1, 2)); //(6)
+  var C2p = sqrt(pow(a2p, 2) + pow(b2, 2)); //(6)
+
+  var hp_f = function(x,y) //(7)
+  {
+    if(x== 0 && y == 0) return 0;
+    else{
+      var tmphp = degrees(atan2(x,y));
+      if(tmphp >= 0) return tmphp
+      else           return tmphp + 360;
+    }
+  }
+
+  var h1p = hp_f(b1, a1p); //(7)
+  var h2p = hp_f(b2, a2p); //(7)
+
+  /**
+   * Step 2: Calculate dLp, dCp, dHp
+   */
+  var dLp = L2 - L1; //(8)
+  var dCp = C2p - C1p; //(9)
+
+  var dhp_f = function(C1, C2, h1p, h2p) //(10)
+  {
+    if(C1*C2 == 0)               return 0;
+    else if(abs(h2p-h1p) <= 180) return h2p-h1p;
+    else if((h2p-h1p) > 180)     return (h2p-h1p)-360;
+    else if((h2p-h1p) < -180)    return (h2p-h1p)+360;
+    else                         throw(new Error());
+  }
+  var dhp = dhp_f(C1,C2, h1p, h2p); //(10)
+  var dHp = 2*sqrt(C1p*C2p)*sin(radians(dhp)/2.0); //(11)
+
+  /**
+   * Step 3: Calculate CIEDE2000 Color-Difference
+   */
+  var a_L = (L1 + L2) / 2.0; //(12)
+  var a_Cp = (C1p + C2p) / 2.0; //(13)
+
+  var a_hp_f = function(C1, C2, h1p, h2p) { //(14)
+    if(C1*C2 == 0)                                      return h1p+h2p
+    else if(abs(h1p-h2p)<= 180)                         return (h1p+h2p)/2.0;
+    else if((abs(h1p-h2p) > 180) && ((h1p+h2p) < 360))  return (h1p+h2p+360)/2.0;
+    else if((abs(h1p-h2p) > 180) && ((h1p+h2p) >= 360)) return (h1p+h2p-360)/2.0;
+    else                                                throw(new Error());
+  }
+  var a_hp = a_hp_f(C1,C2,h1p,h2p); //(14)
+  var T = 1-0.17*cos(radians(a_hp-30))+0.24*cos(radians(2*a_hp))+
+    0.32*cos(radians(3*a_hp+6))-0.20*cos(radians(4*a_hp-63)); //(15)
+  var d_ro = 30 * exp(-(pow((a_hp-275)/25,2))); //(16)
+  var RC = sqrt((pow(a_Cp, 7.0)) / (pow(a_Cp, 7.0) + pow(25.0, 7.0)));//(17)
+  var SL = 1 + ((0.015 * pow(a_L - 50, 2)) /
+                sqrt(20 + pow(a_L - 50, 2.0)));//(18)
+  var SC = 1 + 0.045 * a_Cp;//(19)
+  var SH = 1 + 0.015 * a_Cp * T;//(20)
+  var RT = -2 * RC * sin(radians(2 * d_ro));//(21)
+  var dE = sqrt(pow(dLp /(SL * kL), 2) + pow(dCp /(SC * kC), 2) +
+                pow(dHp /(SH * kH), 2) + RT * (dCp /(SC * kC)) *
+                (dHp / (SH * kH))); //(22)
+  return dE;
+}
+
+/**
+ * INTERNAL FUNCTIONS
+ */
+function degrees(n) { return n*(180/PI); }
+function radians(n) { return n*(PI/180); }
+
+// Local Variables:
+// allout-layout: t
+// js-indent-level: 2
+// End:
+
+},{}],40:[function(require,module,exports){
+'use strict';
+
+var diff = require(39);
+var convert = require(38);
+var palette = require(41);
+
+var color = module.exports = {};
+
+color.diff             = diff.ciede2000;
+color.rgb_to_lab       = convert.rgb_to_lab;
+color.map_palette      = palette.map_palette;
+color.palette_map_key  = palette.palette_map_key;
+
+color.closest = function(target, relative) {
+    var key = color.palette_map_key(target);
+
+    var result = color.map_palette([target], relative, 'closest');
+
+    return result[key];
+};
+
+color.furthest = function(target, relative) {
+    var key = color.palette_map_key(target);
+
+    var result = color.map_palette([target], relative, 'furthest');
+
+    return result[key];
+};
+
+},{}],41:[function(require,module,exports){
+/**
+ * @author Markus Ekholm
+ * @copyright 2012-2015 (c) Markus Ekholm <markus at botten dot org >
+ * @license Copyright (c) 2012-2015, Markus Ekholm
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of the <organization> nor the
+ *      names of its contributors may be used to endorse or promote products
+ *      derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL MARKUS EKHOLM BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+* EXPORTS
+*/
+exports.map_palette     = map_palette;
+exports.palette_map_key = palette_map_key;
+
+/**
+* IMPORTS
+*/
+var color_diff    = require(39);
+var color_convert = require(38);
+
+/**
+ * API FUNCTIONS
+ */
+
+/**
+* Returns the hash key used for a {rgbcolor} in a {palettemap}
+* @param {rgbcolor} c should have fields R,G,B
+* @return {string}
+*/
+function palette_map_key(c)
+{
+  return "R" + c.R + "B" + c.B + "G" + c.G;
+}
+
+/**
+* Returns a mapping from each color in a to the closest color in b
+* @param [{rgbcolor}] a each element should have fields R,G,B
+* @param [{rgbcolor}] b each element should have fields R,G,B
+* @param 'type' should be the string 'closest' or 'furthest'
+* @return {palettemap}
+*/
+function map_palette(a, b, type)
+{
+  var c = {};
+  type = type || 'closest';
+  for (var idx1 = 0; idx1 < a.length; idx1 += 1){
+    var color1 = a[idx1];
+    var best_color      = undefined;
+    var best_color_diff = undefined;
+    for (var idx2 = 0; idx2 < b.length; idx2 += 1)
+    {
+      var color2 = b[idx2];
+      var current_color_diff = diff(color1,color2);
+
+      if((best_color == undefined) || ((type === 'closest') && (current_color_diff < best_color_diff)))
+      {
+        best_color      = color2;
+        best_color_diff = current_color_diff;
+        continue;
+      }
+      if((type === 'furthest') && (current_color_diff > best_color_diff))
+      {
+        best_color      = color2;
+        best_color_diff = current_color_diff;
+        continue;
+      }
+    }
+    c[palette_map_key(color1)] = best_color;
+  }
+  return c;
+}
+
+/**
+ * INTERNAL FUNCTIONS
+ */
+
+function diff(c1,c2)
+{
+  c1 = color_convert.rgb_to_lab(c1);
+  c2 = color_convert.rgb_to_lab(c2);
+  return color_diff.ciede2000(c1,c2);
+}
+
+// Local Variables:
+// allout-layout: t
+// js-indent-level: 2
+// End:
+
+},{}],42:[function(require,module,exports){
+(function (process){
+'use strict';
+var argv = process.argv;
+
+module.exports = (function () {
+	if (argv.indexOf('--no-color') !== -1 ||
+		argv.indexOf('--no-colors') !== -1 ||
+		argv.indexOf('--color=false') !== -1) {
+		return false;
+	}
+
+	if (argv.indexOf('--color') !== -1 ||
+		argv.indexOf('--colors') !== -1 ||
+		argv.indexOf('--color=true') !== -1 ||
+		argv.indexOf('--color=always') !== -1) {
+		return true;
+	}
+
+	if (process.stdout && !process.stdout.isTTY) {
+		return false;
+	}
+
+	if (process.platform === 'win32') {
+		return true;
+	}
+
+	if ('COLORTERM' in process.env) {
+		return true;
+	}
+
+	if (process.env.TERM === 'dumb') {
+		return false;
+	}
+
+	if (/^screen|^xterm|^vt100|color|ansi|cygwin|linux/i.test(process.env.TERM)) {
+		return true;
+	}
+
+	return false;
+})();
+
+}).call(this,require(23))
+},{}]},{},[15])(15)
+});


### PR DESCRIPTION
I think it would provide new users with better feedback if javascript-koans used unexpected instead of the build in `expect` from Jasmine. Unexpected is just better in all aspects than the Jasmine `expect`. It provides colored error messaged with helpful diffs. It is also has better documentation and many more features. See https://unexpectedjs.github.io for more information.

I know this is not the kind of pull request a project normally want, but I think unexpected would fit nicely with javascript-koans. There will be no hard feelings if you just reject the pull request, but I of cause hope you would consider it. That might also make me want to contribute further to the koans in the future.

Kind regards. 
