### PR TITLE
Add note: koan 53 requires older chain() syntax for underscore 1.1.6

### DIFF
--- a/koans/AboutApplyingWhatWeHaveLearnt.js
+++ b/koans/AboutApplyingWhatWeHaveLearnt.js
@@ -82,6 +82,9 @@ describe("About Applying What We Have Learnt", function() {
     var ingredientCount = { "{ingredient name}": 0 };
 
     /* chain() together map(), flatten() and reduce() */
+    // notice: these koans use an older underscore library, 1.1.6
+    // The newer chain syntax _.chain(collection) will cause errors.
+    // Use instead the syntax _(collection).chain()
 
     expect(ingredientCount['mushrooms']).toBe(FILL_ME_IN);
   });


### PR DESCRIPTION
A note has been added for the last koan indicating the syntax required.

Using a more recent chain syntax, `_.chain(collection)`, will cause errors.
Koan 53 requires the original syntax : `_(collection).chain`

Addresses Issue #64
