### PR TITLE
Update broken link to Underscore.js docs

### DIFF
--- a/koans/AboutHigherOrderFunctions.js
+++ b/koans/AboutHigherOrderFunctions.js
@@ -1,6 +1,6 @@
 var _; //globals
 
-/* This section uses a functional extension known as Underscore.js - http://documentcloud.github.com/underscore/
+/* This section uses a functional extension known as Underscore.js - http://underscorejs.org/
      "Underscore is a utility-belt library for JavaScript that provides a lot of the functional programming support
       that you would expect in Prototype.js (or Ruby), but without extending any of the built-in JavaScript objects.
       It's the tie to go along with jQuery's tux."


### PR DESCRIPTION
Old link 404's on Github Document Cloud.
