### PR TITLE
type attribute not required in HTML5

### DIFF
--- a/KoansRunner.html
+++ b/KoansRunner.html
@@ -1,30 +1,29 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-  "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 <html>
 <head>
   <title>Javascript Koans</title>
   <link rel="stylesheet" type="text/css" href="lib/jasmine/jskoans-jasmine.css">
-  <script type="text/javascript" src="lib/jasmine/jasmine.js"></script>
-  <script type="text/javascript" src="lib/jasmine/jasmine-html.js"></script>
-  <script type="text/javascript" src="lib/jasmine/jskoans-jasmine-html.js"></script>
+  <script src="lib/jasmine/jasmine.js"></script>
+  <script src="lib/jasmine/jasmine-html.js"></script>
+  <script src="lib/jasmine/jskoans-jasmine-html.js"></script>
   
-  <script type="text/javascript" src="lib/underscore-min.js"></script>
+  <script src="lib/underscore-min.js"></script>
 
-  <script type="text/javascript" src="lib/FILL_ME_IN.js"></script>
+  <script src="lib/FILL_ME_IN.js"></script>
 
-  <script type="text/javascript" src="koans/AboutExpects.js"></script>
-  <script type="text/javascript" src="koans/AboutArrays.js"></script>
-  <script type="text/javascript" src="koans/AboutFunctions.js"></script>
-  <script type="text/javascript" src="koans/AboutObjects.js"></script>
-  <script type="text/javascript" src="koans/AboutMutability.js"></script>
-  <script type="text/javascript" src="koans/AboutHigherOrderFunctions.js"></script>
-  <script type="text/javascript" src="koans/AboutInheritance.js"></script>
-  <script type="text/javascript" src="koans/AboutApplyingWhatWeHaveLearnt.js"></script>
+  <script src="koans/AboutExpects.js"></script>
+  <script src="koans/AboutArrays.js"></script>
+  <script src="koans/AboutFunctions.js"></script>
+  <script src="koans/AboutObjects.js"></script>
+  <script src="koans/AboutMutability.js"></script>
+  <script src="koans/AboutHigherOrderFunctions.js"></script>
+  <script src="koans/AboutInheritance.js"></script>
+  <script src="koans/AboutApplyingWhatWeHaveLearnt.js"></script>
 
 </head>
 <body>
 
-<script type="text/javascript">
+<script>
   jasmine.getEnv().addReporter(new JsKoansReporter());
   jasmine.getEnv().execute();
 </script>

--- a/jasmine/runner_specs/TestJSKoansRunner.html
+++ b/jasmine/runner_specs/TestJSKoansRunner.html
@@ -1,21 +1,20 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-  "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 <html>
 <head>
   <title>Jasmine Test Runner</title>
   <link rel="stylesheet" type="text/css" href="../../jasmine/jasmine.css">
-  <script type="text/javascript" src="../jasmine.js"></script>
-  <script type="text/javascript" src="../jasmine-html.js"></script>
+  <script src="../jasmine.js"></script>
+  <script src="../jasmine-html.js"></script>
 
   <!-- include source files here... -->
-  <script type="text/javascript" src="../jskoans-jasmine-html.js"></script>
+  <script src="../jskoans-jasmine-html.js"></script>
 
   <!-- include spec files here... -->
-  <script type="text/javascript" src="suites/KoansRunnerSpec.js"></script>
+  <script src="suites/KoansRunnerSpec.js"></script>
 
 </head>
 <body>
-<script type="text/javascript">
+<script>
   jasmine.getEnv().addReporter(new jasmine.TrivialReporter());
   jasmine.getEnv().execute();
 </script>


### PR DESCRIPTION
Removed type attribute from <script> form, cos javascript is default scripting language in HTML5, and it's not needed to define JS.

Flagged html documents from HTML4 --> HTML5