### PR TITLE
Fix broken reference link in AboutArrays.js

### DIFF
--- a/koans/AboutArrays.js
+++ b/koans/AboutArrays.js
@@ -3,7 +3,7 @@ describe("About Arrays", function() {
   //We shall contemplate truth by testing reality, via spec expectations.
   it("should create arrays", function() {
     var emptyArray = [];
-    expect(typeof(emptyArray)).toBe(FILL_ME_IN); //A mistake? - http://javascript.crockford.com/remedial.html
+    expect(typeof(emptyArray)).toBe(FILL_ME_IN); //A mistake? - http://crockford.com/javascript/remedial.html
     expect(emptyArray.length).toBe(FILL_ME_IN);
 
     var multiTypeArray = [0, 1, "two", function () { return 3; }, {value1: 4, value2: 5}, [6, 7]];


### PR DESCRIPTION
Original file linked to javascript.crockford.com, which redirected to crockford.com/javascript. The correct link is crockford.com/javascript/remedial.html.