### PR TITLE
Update old Doug Crockford URLs.

### DIFF
--- a/koans/AboutArrays.js
+++ b/koans/AboutArrays.js
@@ -3,7 +3,7 @@ describe("About Arrays", function() {
   //We shall contemplate truth by testing reality, via spec expectations.
   it("should create arrays", function() {
     var emptyArray = [];
-    expect(typeof(emptyArray)).toBe(FILL_ME_IN); //A mistake? - http://javascript.crockford.com/remedial.html
+    expect(typeof(emptyArray)).toBe(FILL_ME_IN); //A mistake? - https://www.crockford.com/javascript/remedial.html
     expect(emptyArray.length).toBe(FILL_ME_IN);
 
     var multiTypeArray = [0, 1, "two", function () { return 3; }, {value1: 4, value2: 5}, [6, 7]];

--- a/koans/AboutInheritance.js
+++ b/koans/AboutInheritance.js
@@ -42,7 +42,7 @@ describe("About inheritance", function() {
   });
 });
 
-// https://crockford.com/javascript/prototypal.html
+// https://www.crockford.com/javascript/prototypal.html
 Object.prototype.beget = function () {
   function F() {}
   F.prototype = this;

--- a/koans/AboutInheritance.js
+++ b/koans/AboutInheritance.js
@@ -42,7 +42,7 @@ describe("About inheritance", function() {
   });
 });
 
-// http://javascript.crockford.com/prototypal.html
+// https://crockford.com/javascript/prototypal.html
 Object.prototype.beget = function () {
   function F() {}
   F.prototype = this;


### PR DESCRIPTION
Doug Crockford's website no longer resolves links of the form:
- `javascript.crockford.com/example.html`

These formats work:
- `www.crockford.com/javascript/example.html`
- `crockford.com/javascript/example.html`

Also, use HTTPS instead of HTTP.